### PR TITLE
Use String::from_utf8_lossy() for task description output

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -393,10 +393,7 @@ impl TTApp {
         let task_id = self.tasks.lock().unwrap()[selected].id().unwrap_or_default();
         let output = Command::new("task").arg(format!("{}", task_id)).output();
         if let Ok(output) = output {
-            let data = String::from_utf8(output.stdout).unwrap_or(format!(
-                "Unable to get description of task with id: {}. Please report as an issue on github.",
-                task_id
-            ));
+            let data = String::from_utf8_lossy(&*output.stdout);
             let p = Paragraph::new(Text::from(&data[..])).block(
                 Block::default()
                     .borders(Borders::ALL)


### PR DESCRIPTION
Sometimes `task <id>` outputs invalid UTF-8 characters. 
This causes the task description in `taskwarrior-tui` to break completely since right now it uses `String::from_utf8` 
which fails if it encounters an invalid character.
However, it would be obviously better to let the user see the description with invalid characters replaced with "�", 
rather than to see nothing at all.

`String::from_utf8_lossy` does exactly that.