### PR TITLE
Fix colour defaults to support dark terminals

### DIFF
--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -39,7 +39,7 @@ impl<'a> Default for Calendar<'a> {
             year,
             month,
             date_style: vec![],
-            title_background_color: Color::White,
+            title_background_color: Color::Reset,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,8 +20,8 @@ impl Default for TColor {
 impl TColor {
     pub fn default() -> Self {
         Self {
-            fg: Color::Black,
-            bg: Color::White,
+            fg: Color::Reset,
+            bg: Color::Reset,
             modifiers: vec![],
         }
     }
@@ -99,9 +99,9 @@ impl Config {
             uda_selection_blink: Self::get_uda_selection_blink(),
             uda_calendar_months_per_row: Self::get_uda_months_per_row(),
             uda_style_calendar_title: Self::get_uda_style("calendar.title")
-                .unwrap_or(TColor::new(Color::Black, Color::Rgb(220, 220, 220), vec![])),
+                .unwrap_or(TColor::new(Color::Reset, Color::Reset, vec![])),
             uda_style_context_active: Self::get_uda_style("context.active")
-                .unwrap_or(TColor::new(Color::Black, Color::Rgb(220, 220, 220), vec![])),
+                .unwrap_or(TColor::new(Color::Reset, Color::Reset, vec![])),
         })
     }
 
@@ -166,8 +166,8 @@ impl Config {
         }
         let foreground = foreground.replace("inverse ", "");
         TColor {
-            fg: Self::get_color_foreground(foreground.as_str(), Color::Black),
-            bg: Self::get_color_background(background.as_str(), Color::White),
+            fg: Self::get_color_foreground(foreground.as_str(), Color::Reset),
+            bg: Self::get_color_background(background.as_str(), Color::Reset),
             modifiers,
         }
     }


### PR DESCRIPTION
Change `TColor` default values to `Color::Reset` instead of `Color::Black` and `Color::White` in order to improve readability in dark terminal themes as well as light ones.

This causes `taskwarrior-tui` to inherit default terminal colour values from the terminal theme instead of deciding that white should be the background.

This solves an issue where a task has a highlight colour where only the foreground is defined and then adopts `Color::White` as a default variable. This is very difficult to read when using light coloured foreground text.

Please see attached screenshots (left: before patch, right: after patch).

![Screen Shot 2020-11-15 at 18 01 48](https://user-images.githubusercontent.com/1522460/99181921-a1959300-2785-11eb-9712-1f1bed539d97.png)
![Screen Shot 2020-11-15 at 18 03 06](https://user-images.githubusercontent.com/1522460/99181926-a4908380-2785-11eb-97f5-75ce51f3c411.png)
