### PR TITLE
Fix virtual tags parsing for tasks with long words

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1058,10 +1058,12 @@ impl TTApp {
             Ok(output) => {
                 let data = String::from_utf8_lossy(&output.stdout);
                 for line in data.split('\n') {
-                    if line.starts_with("Virtual tags") {
-                        let line = line.to_string();
-                        let line = line.replace("Virtual tags", "");
-                        return Ok(line);
+                    for prefix in vec!["Virtual tags", "Virtual"] {
+                        if line.starts_with(prefix) {
+                            let line = line.to_string();
+                            let line = line.replace(prefix, "");
+                            return Ok(line);
+                        }
                     }
                 }
                 Err(format!(


### PR DESCRIPTION
"task <id>" is aware of terminal width. It can therefore print labels
such as "Virtual tags" in the report over several lines if the terminal
width is too small to acommodate the entirety of all words in the task
in a single line.

---

To reproduce, try creating a task with a long word `task add $(printf "%0100d" "0")`. Compare the output of `task <id>` in terminals with various widths.

![screenshot-210101-193254](https://user-images.githubusercontent.com/6341745/103444406-40a81880-4c68-11eb-9d50-d9e6c674f1d5.png)