### PR TITLE
Fix cargo test errors/warnings

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1623,7 +1623,7 @@ mod tests {
 
     #[test]
     fn test_app() {
-        let mut app = TTApp::new().unwrap();
+        let app = TTApp::new().unwrap();
 
         let (contexts, headers) = app.get_all_contexts();
         dbg!(contexts);

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,6 @@ mod tests {
             };
 
         }
-        destruct_terminal(terminal);
+        destruct_terminal();
     }
 }


### PR DESCRIPTION
Hey!
I was building the latest version (`0.9.10`) of taskwarrior-tui for Arch Linux and came across a few issues pointed out by `cargo test`:

1.

```
error[E0061]: this function takes 0 arguments but 1 argument was supplied
   --> src/main.rs:159:9
    |
159 |         destruct_terminal(terminal);
    |         ^^^^^^^^^^^^^^^^^ -------- supplied 1 argument
    |         |
    |         expected 0 arguments
    |
note: function defined here
   --> src/util.rs:55:8
    |
55  | pub fn destruct_terminal() {
    |        ^^^^^^^^^^^^^^^^^
```

This was caused by 79f1b9c1e69bfac8ca5723f4107d106562f74129:

https://github.com/kdheepak/taskwarrior-tui/blob/79f1b9c1e69bfac8ca5723f4107d106562f74129/src/util.rs#L54-L58

 It removed the parameters from `destruct_terminal` but tests wasn't updated:

https://github.com/kdheepak/taskwarrior-tui/blob/79f1b9c1e69bfac8ca5723f4107d106562f74129/src/main.rs#L160

f83baa5 fixes this error.

---

2.

```
warning: variable does not need to be mutable
    --> src/app.rs:1626:13
     |
1626 |         let mut app = TTApp::new().unwrap();
     |             ----^^^
     |             |
     |             help: remove this `mut`
     |
     = note: `#[warn(unused_mut)]` on by default
```

eb6b6bd fixes this little warning.

---

Having a new release after merging this would be really awesome 😊 
