### PR TITLE
Don't crash immediately if invalid filter

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -700,7 +700,7 @@ impl TTApp {
 
     pub fn update(&mut self) -> Result<(), Box<dyn Error>> {
         self.task_report_table.export_headers()?;
-        self.export_tasks()?;
+        let _ = self.export_tasks();
         self.export_contexts()?;
         self.update_tags();
         Ok(())


### PR DESCRIPTION
Fixes #77 and makes #46 not result in an immediate crash.