### PR TITLE
Get default filter from taskrc (fixes #92)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -169,7 +169,7 @@ impl TTApp {
             help_popup: Help::new(),
             contexts: vec![],
         };
-        for c in "status:pending ".chars() {
+        for c in app.config.default_filter.chars() {
             app.filter.insert(c, 1);
         }
         app.get_context()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,7 @@ impl TaskWarriorBool for str {
 pub struct Config {
     pub enabled: bool,
     pub color: HashMap<String, TColor>,
+    pub default_filter: String,
     pub obfuscate: bool,
     pub print_empty_columns: bool,
     pub rule_precedence_color: Vec<String>,
@@ -86,6 +87,7 @@ impl Config {
             obfuscate: bool_collection.get("obfuscate").cloned().unwrap_or(false),
             print_empty_columns: bool_collection.get("print_empty_columns").cloned().unwrap_or(false),
             color: Self::get_color_collection()?,
+            default_filter: Self::get_default_filter(),
             rule_precedence_color: Self::get_rule_precedence_color(),
             uda_task_report_show_info: Self::get_uda_task_report_show_info(),
             uda_task_report_looping: Self::get_uda_task_report_looping(),
@@ -308,6 +310,10 @@ impl Config {
             .filter(|s| !s.ends_with('.'))
             .map(|s| s.to_string())
             .collect::<Vec<_>>()
+    }
+
+    fn get_default_filter() -> String {
+        Self::get_config("report.next.filter")
     }
 
     fn get_uda_task_report_show_info() -> bool {


### PR DESCRIPTION
This fixes #92

`master` branch is currently crashing when I edit the filter, or sometimes randomly on startup, but that does not occur when my patch is applied on the `v0.9.15` tag.