### PR TITLE
Improve CPU usage by invoking `task` less often

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all
+          args: --all -- --nocapture
 
   fmt:
     name: Rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdb7831b2d85ddf4a7b148aa19d0587eddbe8671a436b7bd1182eaad0f2829"
+dependencies = [
+ "dirs-next",
+]
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +822,7 @@ dependencies = [
  "rustyline",
  "serde",
  "serde_json",
+ "shellexpand",
  "shlex",
  "task-hookrs",
  "tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ crossterm = { version = "0.17", optional = true, default-features = false }
 rustyline = "7.1.0"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 better-panic = "0.2.0"
+shellexpand = "2.1"
 
 [package.metadata.rpm]
 package = "taskwarrior-tui"

--- a/src/app.rs
+++ b/src/app.rs
@@ -552,19 +552,13 @@ impl TTApp {
     fn task_by_uuid(&self, uuid: Uuid) -> Option<Task> {
         let tasks = &self.tasks.lock().unwrap();
         let m = tasks.iter().find(|t| *t.uuid() == uuid);
-        match m {
-            Some(v) => Some(v.clone()),
-            None => None,
-        }
+        m.cloned()
     }
 
     fn task_by_id(&self, id: u64) -> Option<Task> {
         let tasks = &self.tasks.lock().unwrap();
         let m = tasks.iter().find(|t| t.id().unwrap() == id);
-        match m {
-            Some(v) => Some(v.clone()),
-            None => None,
-        }
+        m.cloned()
     }
 
     fn style_for_task(&self, task: &Task) -> Style {
@@ -906,7 +900,7 @@ impl TTApp {
 
         for (i, line) in data.trim().split('\n').enumerate() {
             let line = line.trim();
-            if line == "" || line == "Use 'task context none' to unset the current context." {
+            if line.is_empty() || line == "Use 'task context none' to unset the current context." {
                 continue;
             }
             let mut s = line.split(' ');

--- a/src/app.rs
+++ b/src/app.rs
@@ -1410,6 +1410,7 @@ impl TTApp {
                     let reference = TimeZone::from_utc_datetime(now.offset(), d);
                     let now = TimeZone::from_utc_datetime(now.offset(), &now.naive_utc());
                     let d = d.clone();
+                    dbg!(reference, now);
                     if (reference - chrono::Duration::nanoseconds(1)).month() == now.month() {
                         add_tag(&mut task, "MONTH".to_string());
                     }
@@ -2003,14 +2004,9 @@ mod tests {
 
         let mut command = Command::new("task");
         command.arg("add");
-        let message = format!(
-            "'new task for testing earlier today' due:{:04}-{:02}-{:02}",
-            now.year(),
-            now.month(),
-            now.day()
-        );
+        let message = "'new task for testing earlier today' due:now";
 
-        let shell = message.as_str().replace("'", "\\'");
+        let shell = message.replace("'", "\\'");
         let cmd = shlex::split(&shell).unwrap();
         for s in cmd {
             command.arg(&s);
@@ -2040,6 +2036,7 @@ mod tests {
             "UNBLOCKED",
             "YEAR",
         ] {
+            dbg!(s, task.tags());
             assert!(task.tags().unwrap().contains(&s.to_string()));
         }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,11 +11,11 @@ use crate::util::{Event, Events};
 use std::cmp::Ordering;
 use std::convert::TryInto;
 use std::error::Error;
+use std::fs;
+use std::path::Path;
 use std::process::Command;
 use std::result::Result;
 use std::time::SystemTime;
-use std::fs;
-use std::path::Path;
 
 use task_hookrs::date::Date;
 use task_hookrs::import::import;
@@ -950,13 +950,12 @@ impl TTApp {
                         // time shifts, cap maximum wait to 1 min
                         let now = SystemTime::now();
                         let max_delta = Duration::from_secs(60);
-                        Ok(now.duration_since(prev)? >  max_delta)
+                        Ok(now.duration_since(prev)? > max_delta)
                     }
-                },
+                }
                 Err(_) => Ok(true),
             }
-        }
-        else {
+        } else {
             Ok(true)
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,7 @@ pub struct Config {
     pub enabled: bool,
     pub color: HashMap<String, Style>,
     pub filter: String,
+    pub data_location: String,
     pub obfuscate: bool,
     pub print_empty_columns: bool,
     pub due: usize,
@@ -62,6 +63,7 @@ impl Config {
             print_empty_columns: bool_collection.get("print_empty_columns").cloned().unwrap_or(false),
             color: Self::get_color_collection()?,
             filter: Self::get_filter(),
+            data_location: Self::get_data_location(),
             due: Self::get_due(),
             rule_precedence_color: Self::get_rule_precedence_color(),
             uda_task_report_show_info: Self::get_uda_task_report_show_info(),
@@ -294,6 +296,10 @@ impl Config {
 
     fn get_filter() -> String {
         Self::get_config("report.next.filter")
+    }
+
+    fn get_data_location() -> String {
+        Self::get_config("data.location")
     }
 
     fn get_uda_task_report_show_info() -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ fn tui_main(_config: &str) -> Result<(), Box<dyn Error>> {
                         }
                     }
                     Event::Tick => {
-                        let r = app.update();
+                        let r = app.update(false);
                         if r.is_err() {
                             destruct_terminal();
                             return r;


### PR DESCRIPTION
Only invoke `task` to export tasks data when `pending.data` taskwarrior file has changed.

This allows catching task changes made by `taskwarrior-tui` itself, but also by other programs that may modify the task database. As a safety to handle system clock changes, update at least once per minute.

See #122 for previous discussion.

**This reduces average CPU usage on my system from 46% to 2% when idle during one minute.**