### PR TITLE
Fix behavior of context filters with "or" keywords.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: sudo apt-get update && sudo apt-get install -y taskwarrior taskd
+      - run: sudo apt-get update && sudo apt-get install -y taskwarrior
       - uses: actions/checkout@v2
         with:
           repository: kdheepak/taskwarrior-testdata

--- a/src/app.rs
+++ b/src/app.rs
@@ -975,7 +975,7 @@ impl TTApp {
         task.arg("export");
 
         let filter = if !self.current_context_filter.is_empty() {
-            let t = format!("{} {}", self.filter.as_str(), self.current_context_filter);
+            let t = format!("{} '\\({}\\)'", self.filter.as_str(), self.current_context_filter);
             t
         } else {
             self.filter.as_str().into()


### PR DESCRIPTION
This corrects the behavior of context filters with `or` keywords.

The previous filter for the export command is a string concatenation of the filter strings and context filter, e.g., for a default filter of `status:pending` and a context filter of `+tag1 or +tag2` the resulting export command is `task export status:pending +tag1 or +tag2`

This would display tasks that are either pending with tag1 or _any task_ with tag2, including completed tasks. Per the [Taskwarrior docs on precedence](https://taskwarrior.org/docs/filter.html#prec), we need escaped, surrounding parentheses, e.g. `task export status:pending '\(+tag1 or +tag2\)'`

As a workaround, the parentheses can be added when defining the context. Taskwarrior CLI doesn't require the parentheses around the context, so this update aligns context behavior with the CLI.