### PR TITLE
Update top/bottom keybindings to g/G

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -25,7 +25,7 @@ Keybindings for task report:
 
     K: {selected-=pageheight}            - Move page up in task report
 
-    gg: {selected=last}                  - Go to top
+    g: {selected=first}                  - Go to top
 
     G: {selected=last}                   - Go to bottom
 

--- a/docs/taskwarrior-tui.1.md
+++ b/docs/taskwarrior-tui.1.md
@@ -70,8 +70,8 @@ Keybindings for task report:
 `K`
 : {selected-=pageheight}            - Move page up in task report
 
-`gg`
-: {selected=last}                  - Go to top
+`g`
+: {selected=first}                  - Go to top
 
 `G`
 : {selected=last}                   - Go to bottom

--- a/src/keyconfig.rs
+++ b/src/keyconfig.rs
@@ -38,8 +38,8 @@ impl Default for KeyConfig {
         Self {
             quit: Key::Char('q'),
             refresh: Key::Char('r'),
-            go_to_bottom: Key::End,
-            go_to_top: Key::Home,
+            go_to_bottom: Key::Char('G'),
+            go_to_top: Key::Char('g'),
             down: Key::Char('j'),
             up: Key::Char('k'),
             page_down: Key::Char('J'),


### PR DESCRIPTION
This updates the default first/last keybindings to (mostly) match the help file and VIM default bindings, i.e. `g` for top and `G` for bottom. The previous defaults were set to Home and End. The only difference is that since all keybindings are single characters, it's just `g` instead of `gg`.

Also this updates the help docs to just `g` instead of `gg`