### PR TITLE
Remove support for using `0` as shortcut key

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -47,7 +47,7 @@ Keybindings for task report:
 
     !: {string}                          - Custom shell command
 
-    0-9: {string}                        - Run user defined shortcuts
+    1-9: {string}                        - Run user defined shortcuts
 
     c: context switcher menu             - Open context switcher menu
 

--- a/docs/taskwarrior-tui.1.md
+++ b/docs/taskwarrior-tui.1.md
@@ -103,7 +103,7 @@ Keybindings for task report:
 `!`
 : {string}                          - Custom shell command
 
-`0-9`
+`1-9`
 : {string}                          - Run user defined shortcuts
 
 `c`

--- a/src/app.rs
+++ b/src/app.rs
@@ -1603,14 +1603,6 @@ impl TTApp {
                     self.mode = AppMode::TaskHelpPopup;
                 } else if input == self.keyconfig.filter {
                     self.mode = AppMode::TaskFilter;
-                } else if input == self.keyconfig.shortcut0 {
-                    match self.task_shortcut(0) {
-                        Ok(_) => self.update(true)?,
-                        Err(e) => {
-                            self.mode = AppMode::TaskError;
-                            self.error = e;
-                        }
-                    }
                 } else if input == self.keyconfig.shortcut1 {
                     match self.task_shortcut(1) {
                         Ok(_) => self.update(true)?,


### PR DESCRIPTION
Reserve `0` for later. See: https://github.com/kdheepak/taskwarrior-tui/issues/140#issuecomment-801989907