### PR TITLE
Append space to filter input

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -420,10 +420,11 @@ impl Config {
     }
 
     async fn get_filter() -> String {
-        Self::get_config("report.next.filter")
+        let filter = Self::get_config("report.next.filter")
             .await
             .context("Unable to parse `task show report.next.filter`.")
-            .unwrap()
+            .unwrap();
+        format!("{} ", filter)
     }
 
     async fn get_data_location() -> String {


### PR DESCRIPTION
Since #93, you need to type and extra space whenever editing the filter. This formats the filter so you don't have to.