### PR TITLE
Fix next_page selection calculation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1187,16 +1187,19 @@ impl TaskwarriorTuiApp {
             return;
         }
         let i = {
-            if self.current_selection >= self.tasks.len() - 1 {
+            if self.current_selection == self.tasks.len() - 1 {
                 if self.config.uda_task_report_looping {
                     0
                 } else {
-                    self.current_selection
+                    self.tasks.len() - 1
                 }
             } else {
-                self.current_selection
-                    .checked_add(self.task_report_height as usize)
-                    .unwrap_or_else(|| self.tasks.len())
+                std::cmp::min(
+                    self.current_selection
+                        .checked_add(self.task_report_height as usize)
+                        .unwrap_or_else(|| self.tasks.len() - 1),
+                    self.tasks.len() - 1,
+                )
             }
         };
         self.current_selection = i;


### PR DESCRIPTION
This fixes an issue with the current_selection overflowing plus keeps the behavior consistent with prev_page.


Previously, used to get this error if I where to use `J` to go to next_page towards the end: 
```
Backtrace (most recent call first):
  File "rust:library/core/src/panicking.rs", line 69, in core::panicking::panic_bounds_check
  File "<unknown>", line 0, in taskwarrior_tui::app::TaskwarriorTuiApp::draw_task
  File "<unknown>", line 0, in tui::terminal::Terminal<B>::draw
  File "<unknown>", line 0, in std::thread::local::LocalKey<T>::with
  File "<unknown>", line 0, in <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
  File "<unknown>", line 0, in async_io::driver::block_on
  File "<unknown>", line 0, in std::thread::local::LocalKey<T>::with
  File "<unknown>", line 0, in async_std::task::builder::Builder::blocking
  File "<unknown>", line 0, in taskwarrior_tui::main
  File "<unknown>", line 0, in std::sys_common::backtrace::__rust_begin_short_backtrace
  File "<unknown>", line 0, in std::rt::lang_start::{{closure}}
  File "rust:library/core/src/ops/function.rs", line 259, in core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
  File "rust:library/std/src/panicking.rs", line 379, in std::panicking::try::do_call
  File "rust:library/std/src/panicking.rs", line 343, in std::panicking::try
  File "rust:library/std/src/panic.rs", line 431, in std::panic::catch_unwind
  File "rust:library/std/src/rt.rs", line 51, in std::rt::lang_start_internal
  File "<unknown>", line 0, in _main

The application panicked (crashed).
  index out of bounds: the len is 24 but the index is 26
in src/app.rs, line 650
thread: main
```