### PR TITLE
Remove unwrap in time check

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1334,7 +1334,11 @@ impl TaskwarriorTuiApp {
             let mtime = fs::metadata(pending_fp)?.modified()?;
             mtimes.push(mtime);
         }
-        Ok(*mtimes.iter().max().unwrap())
+        if let Some(t) = mtimes.iter().max() {
+            Ok(*t)
+        } else {
+            Err(anyhow!("Unable to get task files max time"))
+        }
     }
 
     pub fn tasks_changed_since(&mut self, prev: Option<SystemTime>) -> Result<bool> {


### PR DESCRIPTION
This fixes #233.

The fix is similar to #234 but is a little more robust in case some but not all of the probed filed are missing or generate an error.