### PR TITLE
Fix report for taskwarrior 2.6

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1484,7 +1484,6 @@ impl TaskwarriorTuiApp {
 
         task.arg("rc.json.array=on");
         task.arg("rc.confirmation=off");
-        task.arg("export");
 
         let filter = if !self.current_context_filter.is_empty() {
             let t = format!("{} '\\({}\\)'", self.filter.as_str(), self.current_context_filter);
@@ -1503,6 +1502,8 @@ impl TaskwarriorTuiApp {
                 task.arg("");
             }
         }
+
+        task.arg("export");
 
         let output = task.output()?;
         let data = String::from_utf8_lossy(&output.stdout);

--- a/src/task_report.rs
+++ b/src/task_report.rs
@@ -80,6 +80,7 @@ impl TaskReportTable {
             "LATEST",
             "RECURRING",
             "INSTANCE",
+            "TEMPLATE",
         ];
         let mut task_report_table = Self {
             labels: vec![],


### PR DESCRIPTION
Filters were being applied after the `export`. This resulted in stuff
like task templates showing up in the task report. If we add the filters
before the `export` then everything works as expected.

Also add `TEMPLATE` as it is a new virtual tag.