### PR TITLE
Fix current read context not being applied

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -304,7 +304,7 @@ impl TaskwarriorTui {
 
         let output = Command::new("task")
             .arg("_get")
-            .arg(format!("rc.context.{}", self.current_context))
+            .arg(format!("rc.context.{}.read", self.current_context))
             .output()?;
         self.current_context_filter = String::from_utf8_lossy(&output.stdout).to_string();
         self.current_context_filter = self.current_context_filter.strip_suffix('\n').unwrap_or("").to_string();


### PR DESCRIPTION
Hi! Taskwarrior 2.6 contexts weren't being applied in the newest tui version. This was due to `task _get rc.context.name` returning an empty string.

```
task --version
2.6.1
```