### PR TITLE
[DOCS] Zinit was removed from the original org

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,7 +46,7 @@ yay -S taskwarrior-tui-git # build from source
 snap install taskwarrior-tui
 ```
 
-**Using [`zdharma/zinit`](https://github.com/zdharma/zinit)** [![](https://img.shields.io/github/v/tag/kdheepak/taskwarrior-tui)](https://github.com/kdheepak/taskwarrior-tui/releases/latest)
+**Using [`zdharma-continuum/zinit`](https://github.com/zdharma-continuum/zinit)** [![](https://img.shields.io/github/v/tag/kdheepak/taskwarrior-tui)](https://github.com/kdheepak/taskwarrior-tui/releases/latest)
 
 Add the following to your `~/.zshrc`:
 


### PR DESCRIPTION
zinit's owner, psprint, deleted the zdharma org and all projects under his account, so I have updated the docs to use the link to the @zdharma-continuum org, which seems to be the community's preference for zdharma mirrors. 