### PR TITLE
fix: Update context tests about task count

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3583,7 +3583,7 @@ mod tests {
         assert!(app.get_context().is_ok());
         assert!(app.update(true).is_ok());
 
-        assert_eq!(app.tasks.len(), 1);
+        assert_eq!(app.tasks.len(), 26);
         assert_eq!(app.current_context_filter, "+finance -private");
 
         assert_eq!(app.contexts.table_state.current_selection(), Some(2));


### PR DESCRIPTION
I had this test failure while building `taskwarrior-tui`:

```
running 8 tests
test app::tests::test_centered_rect ... ok
test config::tests::test_get_config_last_long_value ... ok
test table::tests::table_invalid_percentages - should panic ... ok
test config::tests::test_get_config_long_value ... ok
test config::tests::test_get_config_long_value_followed_by_default_value ... ok
test config::tests::test_colors ... ok
test completion::tests::test_completion ... ok
Importing 'STDIN'
 add  0b11967d-9dae-4333-a137-c3b1e8a641d3 Move between tasks using 'j' and 'k'
 add  f5a18641-dc38-4ae1-80f0-588166a2aa44 Edit task in editor using 'e'
 add  b3f9e124-64c2-4dc0-8351-9b2200e2863e Filter tasks using '/'
 add  62c386dc-4403-4756-a56a-becad2538e77 Undo last action using u
 add  22bba0bf-7fac-4382-9d3f-bce17e981378 Start and Stop task using 's'
 add  b16a359d-427f-4e0f-92eb-8cc07736b6a4 Annotate tasks using 'A'
 add  7bb0e242-4610-475d-98a6-9b75d97be6a7 Log tasks using 'l'
 add  6c4c9ee8-d6c4-4d64-a84d-bf9cb710684e Run custom shell command using '!'
 add  48fe34a2-9991-4ffd-ae0d-ac37d94ac197 Toggle between task and calendar view using '[' and ']'
 add  f8470e92-0286-4b85-91f4-acf6bf693f6c Support color for tasks based on your .taskrc
 add  3f43831b-88dc-45e2-bf0d-4aea6db634cc Add task with 'a'
 add  3c88c2b0-19c8-46d3-aaa3-0f915368ac25 Modify task with 'm'
 add  c490691d-67e1-4bea-92d7-6b9237c54560 тесd
 add  1861bcb6-a199-4bf4-b8b9-d4011749906c ähe
 add  60391ac0-1c29-4ad8-b5c4-b3660422060a Adding task 😂
 add  ca22ab2b-8182-4735-b7d7-d47e6fba3e81 ähellasd
 add  cf7b68e4-1c7b-47ae-9706-65e66b605053 whatever
 add  4748c6a4-8f98-4bb7-8650-a92c971e17e0 Maßnahmen
 add  f3151f54-5628-49be-b977-0f9beb6dd1f4 tui
 add  d63bb624-27f6-4ba5-bb3e-9eed3fb6f389 new task
 add  30fdbcb9-37b9-44ce-8132-35d912bdd087 00000000000000000000000000000000000000000000000000
 add  1e3b4865-d02f-4d41-8f3f-69b53b88c456 asddsfsdfsdfdsfdsfdsfdsfsdfsdfsdfafasfasfdsfsdfsdfsd
 add  acd790f8-47bd-4bdd-ab34-4614f054c864 das
 add  f97c4200-8288-48fd-8e61-b972127a96ed creating a task
 add  88ff806a-f7f5-4107-90b4-8bc4a2c81657 Mark task as done using 'd'
 add  be9c4324-bf96-4f15-904a-4bb8098500fe See help using '?'
 add  456fc642-433b-4bfc-b437-7a3f6449a5ec Delete task using 'x'
 add  02f5517d-3cfd-4669-bb23-82cbaaf8d08e https://github.com/kdheepak/taskw
 add  80bd2a88-22a7-4e11-8ec9-b63af7f1db7d klsdajfadslkfjdaslfkajsdflkjdsaflksdajflksdajfsadlkfjasldfkjasdlkfjlasdfjasldkfjasldkfjlakjdflkajsdflaksdjflaskdjflasdkjfdsklajfalskdjfds
 add  a177437b-7ad6-4569-b7eb-f89e9d7fa905 gdsds
 add  f3a91c08-78ae-4aae-91ba-5c6b17745493 gasfsd
 add  a0609c14-6f4c-4856-9933-adf0e82a0b6b gsdfsd
 add  9e22c54f-1ee5-46c9-a1f7-a9752c898f82 fsdafsda
TASKRC override: ../taskwarrior-testdata/.taskrc
TASKDATA override: ../taskwarrior-testdata/.task
Imported 33 tasks.
test app::tests::test_taskwarrior_tui ... FAILED

failures:

---- app::tests::test_taskwarrior_tui stdout ----
thread 'app::tests::test_taskwarrior_tui' panicked at 'assertion failed: `(left == right)`
  left: `26`,
 right: `1`', src/app.rs:3586:9


failures:
    app::tests::test_taskwarrior_tui

test result: FAILED. 7 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.66s

error: test failed, to rerun pass '--bin taskwarrior-tui'
```

I was able to reproduce it on my local environment so I decided to fix it with a PR.

P.S: I realized some other tests are failing if you run `cargo test` consecutively. While trying to reproduce, before running `cargo test`, I git-restore'd `.taskrc` and removed `.task` directory from `taskwarrior-testdata` to prevent this.

