### PR TITLE
Change behavior of filter when using filter

### DIFF
--- a/docs/configuration/advanced.md
+++ b/docs/configuration/advanced.md
@@ -33,6 +33,7 @@ uda.taskwarrior-tui.task-report.next.filter=$(task show report.next.filter)
 uda.taskwarrior-tui.task-report.auto-insert-double-quotes-on-add=true
 uda.taskwarrior-tui.task-report.auto-insert-double-quotes-on-annotate=true
 uda.taskwarrior-tui.task-report.auto-insert-double-quotes-on-log=true
+uda.taskwarrior-tui.task-report.reset-filter-on-esc=true
 ```
 
 The `uda.taskwarrior-tui.task-report.next.filter` variable defines the default view at program startup. Set this to any preconfigured report (`task reports`), or create your own report in taskwarrior and specify its name here.

--- a/src/app.rs
+++ b/src/app.rs
@@ -3181,7 +3181,13 @@ impl TaskwarriorTui {
                         } else {
                             self.mode = Mode::Tasks(Action::Report);
                             self.filter_history.add(self.filter.as_str());
+                            self.filter.update("", 0);
+                            for c in self.config.filter.chars() {
+                                self.filter.insert(c, 1);
+                            }
                             self.history_status = None;
+                            self.update_input_for_completion();
+                            self.dirty = true;
                             self.update(true)?;
                         }
                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -3181,13 +3181,15 @@ impl TaskwarriorTui {
                         } else {
                             self.mode = Mode::Tasks(Action::Report);
                             self.filter_history.add(self.filter.as_str());
-                            self.filter.update("", 0);
-                            for c in self.config.filter.chars() {
-                                self.filter.insert(c, 1);
+                            if self.config.uda_reset_filter_on_esc {
+                                self.filter.update("", 0);
+                                for c in self.config.filter.chars() {
+                                    self.filter.insert(c, 1);
+                                }
+                                self.update_input_for_completion();
+                                self.dirty = true;
                             }
                             self.history_status = None;
-                            self.update_input_for_completion();
-                            self.dirty = true;
                             self.update(true)?;
                         }
                     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,7 @@ pub struct Config {
     pub uda_auto_insert_double_quotes_on_annotate: bool,
     pub uda_auto_insert_double_quotes_on_log: bool,
     pub uda_prefill_task_metadata: bool,
+    pub uda_reset_filter_on_esc: bool,
     pub uda_task_detail_prefetch: usize,
     pub uda_task_report_show_info: bool,
     pub uda_task_report_looping: bool,
@@ -100,6 +101,7 @@ impl Config {
         let uda_auto_insert_double_quotes_on_annotate = Self::get_uda_auto_insert_double_quotes_on_annotate(data);
         let uda_auto_insert_double_quotes_on_log = Self::get_uda_auto_insert_double_quotes_on_log(data);
         let uda_prefill_task_metadata = Self::get_uda_prefill_task_metadata(data);
+        let uda_reset_filter_on_esc = Self::get_uda_reset_filter_on_esc(data);
         let uda_task_detail_prefetch = Self::get_uda_task_detail_prefetch(data);
         let uda_task_report_show_info = Self::get_uda_task_report_show_info(data);
         let uda_task_report_looping = Self::get_uda_task_report_looping(data);
@@ -151,6 +153,7 @@ impl Config {
             uda_auto_insert_double_quotes_on_annotate,
             uda_auto_insert_double_quotes_on_log,
             uda_prefill_task_metadata,
+            uda_reset_filter_on_esc,
             uda_task_detail_prefetch,
             uda_task_report_show_info,
             uda_task_report_looping,
@@ -473,6 +476,13 @@ impl Config {
             .unwrap_or_default()
             .get_bool()
             .unwrap_or(false)
+    }
+
+    fn get_uda_reset_filter_on_esc(data: &str) -> bool {
+        Self::get_config("uda.taskwarrior-tui.task-report.reset-filter-on-esc", data)
+            .unwrap_or_default()
+            .get_bool()
+            .unwrap_or(true)
     }
 
     fn get_uda_tick_rate(data: &str) -> u64 {


### PR DESCRIPTION
Fixes #356  

Related #198

This PR adds a feature to reset the filter when pressing <kbd>ESC</kbd>. It also adds a configuration option for this behavior.

```
# default / new behavior
uda.taskwarrior-tui.task-report.reset-filter-on-esc=true
# old behavior
uda.taskwarrior-tui.task-report.reset-filter-on-esc=false
```

This PR does not change the behavior of `taskwarrior-tui` when pressing <kbd>Enter</kbd>.