### PR TITLE
Make `start_tui` function synchronous

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -347,7 +347,7 @@ impl TaskwarriorTui {
         Ok(app)
     }
 
-    pub async fn start_tui(&mut self) -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
+    pub fn start_tui(&mut self) -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
         enable_raw_mode()?;
         let mut stdout = std::io::stdout();
         execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ async fn tui_main(report: &str) -> Result<()> {
 
     let mut app = app::TaskwarriorTui::new(report, true).await?;
 
-    let mut terminal = app.start_tui().await?;
+    let mut terminal = app.start_tui()?;
 
     let r = app.run(&mut terminal).await;
 


### PR DESCRIPTION
`cargo clippy -- --deny clippy::unused_async` curiously doesn't catch this, so I opened https://github.com/rust-lang/rust-clippy/issues/9024.