### PR TITLE
Switch to taskwarrior v3.X backend

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -307,7 +307,7 @@ jobs:
           cd /tmp
           git clone https://github.com/GothenburgBitFactory/taskwarrior
           cd taskwarrior
-          git checkout v2.6.1
+          git checkout v3.0.0
           cmake -DCMAKE_BUILD_TYPE=release -DENABLE_SYNC=OFF .
           make
           sudo make install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           cd /tmp
           git clone https://github.com/GothenburgBitFactory/taskwarrior
           cd taskwarrior
-          git checkout v2.6.1
+          git checkout v3.0.0
           cmake -DCMAKE_BUILD_TYPE=release -DENABLE_SYNC=OFF .
           make
           sudo make install

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "taskwarrior-tui"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "better-panic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ taskwarrior-tui = { path = "/usr/bin/taskwarrior-tui" }
 [profile.release]
 debug = 1
 incremental = true
-lto = "off"
+lto = "fat"
 
 [build-dependencies]
 clap = { version = "4.4.1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskwarrior-tui"
-version = "0.25.4"
+version = "0.26.0"
 license = "MIT"
 description = "A Taskwarrior Terminal User Interface"
 repository = "https://github.com/kdheepak/taskwarrior-tui/"
@@ -18,9 +18,7 @@ better-panic = "0.3.0"
 cassowary = "0.3.0"
 chrono = "0.4.26"
 clap = { version = "4.4.1", features = ["derive"] }
-crossterm = { version = "0.27.0", features = [
-  "event-stream",
-] }
+crossterm = { version = "0.27.0", features = ["event-stream"] }
 dirs = "5.0.1"
 futures = "0.3.28"
 itertools = "0.11.0"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `taskwarrior-tui`
 
 > [!IMPORTANT]
-> `taskwarrior-tui` is only tested with `taskwarrior` v2.x. [`taskwarrior` v3.x](https://github.com/GothenburgBitFactory/taskwarrior/releases/tag/v3.0.0) may not work as intended.
+> [`taskwarrior` v3.x](https://github.com/GothenburgBitFactory/taskwarrior/releases/tag/v3.0.0) may break `taskwarrior-tui` features in unexpected ways. Please file a bug report if you encounter a bug. 
 
 [![CI](https://github.com/kdheepak/taskwarrior-tui/workflows/CI/badge.svg)](https://github.com/kdheepak/taskwarrior-tui/actions?query=workflow%3ACI)
 [![](https://img.shields.io/github/license/kdheepak/taskwarrior-tui)](./LICENSE)

--- a/src/app.rs
+++ b/src/app.rs
@@ -3767,6 +3767,8 @@ pub fn remove_tag(task: &mut Task, tag: &str) {
 }
 
 #[cfg(test)]
+// Disabled, as "'" should be a String for more readable shlex shell escaping.
+#[allow(clippy::single_char_pattern)]
 mod tests {
   use std::{ffi::OsStr, fmt::Write, fs::File, io, path::{Path, PathBuf}};
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3768,11 +3768,18 @@ pub fn remove_tag(task: &mut Task, tag: &str) {
 
 #[cfg(test)]
 mod tests {
-  use std::{ffi::OsStr, fmt::Write, fs::File, io, path::Path};
+  use std::{ffi::OsStr, fmt::Write, fs::File, io, path::{Path, PathBuf}};
 
   use ratatui::{backend::TestBackend, buffer::Buffer};
 
   use super::*;
+
+  fn get_taskdata_path() -> PathBuf {
+    let taskdata_env_var = std::env::var("TASKDATA").expect("TASKDATA environment variable not set.");
+    let taskdata_path = Path::new(&taskdata_env_var).to_owned();
+
+    taskdata_path
+  }
 
   /// Returns a string representation of the given buffer for debugging purpose.
   fn buffer_view(buffer: &Buffer) -> String {
@@ -3805,7 +3812,7 @@ mod tests {
 
   fn setup() {
     use std::process::Stdio;
-    let mut f = File::open(Path::new(env!("TASKDATA")).parent().unwrap().join("export.json")).unwrap();
+    let mut f = File::open(get_taskdata_path().parent().unwrap().join("export.json")).unwrap();
     let mut s = String::new();
     f.read_to_string(&mut s).unwrap();
     let tasks = task_hookrs::import::import(s.as_bytes()).unwrap();
@@ -3816,7 +3823,7 @@ mod tests {
   }
 
   fn teardown() {
-    let cd = Path::new(env!("TASKDATA"));
+    let cd = get_taskdata_path();
     std::fs::remove_dir_all(cd).unwrap();
   }
 
@@ -3912,8 +3919,8 @@ mod tests {
       app.task_by_index(0).is_none(),
       "Expected task data to be empty but found {} tasks. Delete contents of {:?} and {:?} and run the tests again.",
       app.tasks.len(),
-      Path::new(env!("TASKDATA")),
-      Path::new(env!("TASKDATA")).parent().unwrap().join(".config")
+      get_taskdata_path(),
+      get_taskdata_path().parent().unwrap().join(".config")
     );
 
     let app = TaskwarriorTui::new("next", false).await.unwrap();

--- a/src/app.rs
+++ b/src/app.rs
@@ -3963,7 +3963,7 @@ mod tests {
 
     let mut app = TaskwarriorTui::new("next", false).await.unwrap();
     let task = app.task_by_id(11).unwrap();
-    let tags = vec!["finance", "UNBLOCKED", "PENDING", "TAGGED", "UDA"]
+    let tags = ["finance", "UNBLOCKED", "PENDING", "TAGGED", "UDA"]
       .iter()
       .map(ToString::to_string)
       .collect::<Vec<String>>();
@@ -3982,7 +3982,7 @@ mod tests {
     app.update(true).await.unwrap();
 
     let task = app.task_by_id(11).unwrap();
-    let tags = vec!["next", "finance", "UNBLOCKED", "PENDING", "TAGGED", "UDA"]
+    let tags = ["next", "finance", "UNBLOCKED", "PENDING", "TAGGED", "UDA"]
       .iter()
       .map(ToString::to_string)
       .collect::<Vec<String>>();
@@ -3994,7 +3994,7 @@ mod tests {
     app.update(true).await.unwrap();
 
     let task = app.task_by_id(11).unwrap();
-    let tags = vec!["finance", "UNBLOCKED", "PENDING", "TAGGED", "UDA"]
+    let tags = ["finance", "UNBLOCKED", "PENDING", "TAGGED", "UDA"]
       .iter()
       .map(ToString::to_string)
       .collect::<Vec<String>>();

--- a/src/app.rs
+++ b/src/app.rs
@@ -3903,16 +3903,8 @@ mod tests {
     // teardown();
   }
 
-  #[test]
-  fn test_taskwarrior_tui() {
-    let r = tokio::runtime::Builder::new_multi_thread()
-      .enable_all()
-      .build()
-      .unwrap()
-      .block_on(async { _test_taskwarrior_tui().await });
-  }
-
-  async fn _test_taskwarrior_tui() {
+  #[tokio::test]
+  async fn test_taskwarrior_tui() {
     let app = TaskwarriorTui::new("next", false).await.unwrap();
 
     assert!(

--- a/src/app.rs
+++ b/src/app.rs
@@ -1304,7 +1304,7 @@ impl TaskwarriorTui {
       self.get_context()?;
       let task_uuids = self.selected_task_uuids();
       if self.current_selection_uuid.is_none() && self.current_selection_id.is_none() && task_uuids.len() == 1 {
-        if let Some(uuid) = task_uuids.get(0) {
+        if let Some(uuid) = task_uuids.first() {
           self.current_selection_uuid = Some(*uuid);
         }
       }
@@ -1798,7 +1798,7 @@ impl TaskwarriorTui {
     };
 
     if task_uuids.len() == 1 {
-      if let Some(uuid) = task_uuids.get(0) {
+      if let Some(uuid) = task_uuids.first() {
         self.current_selection_uuid = Some(*uuid);
       }
     }
@@ -1908,7 +1908,7 @@ impl TaskwarriorTui {
     };
 
     if task_uuids.len() == 1 {
-      if let Some(uuid) = task_uuids.get(0) {
+      if let Some(uuid) = task_uuids.first() {
         self.current_selection_uuid = Some(*uuid);
       }
     }
@@ -1961,7 +1961,7 @@ impl TaskwarriorTui {
     };
 
     if task_uuids.len() == 1 {
-      if let Some(uuid) = task_uuids.get(0) {
+      if let Some(uuid) = task_uuids.first() {
         self.current_selection_uuid = Some(*uuid);
       }
     }
@@ -2013,7 +2013,7 @@ impl TaskwarriorTui {
     };
 
     if task_uuids.len() == 1 {
-      if let Some(uuid) = task_uuids.get(0) {
+      if let Some(uuid) = task_uuids.first() {
         self.current_selection_uuid = Some(*uuid);
       }
     }
@@ -2100,7 +2100,7 @@ impl TaskwarriorTui {
     }
 
     if task_uuids.len() == 1 {
-      if let Some(uuid) = task_uuids.get(0) {
+      if let Some(uuid) = task_uuids.first() {
         self.current_selection_uuid = Some(*uuid);
       }
     }
@@ -2140,7 +2140,7 @@ impl TaskwarriorTui {
     }
 
     if task_uuids.len() == 1 {
-      if let Some(uuid) = task_uuids.get(0) {
+      if let Some(uuid) = task_uuids.first() {
         self.current_selection_uuid = Some(*uuid);
       }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -3770,7 +3770,13 @@ pub fn remove_tag(task: &mut Task, tag: &str) {
 // Disabled, as "'" should be a String for more readable shlex shell escaping.
 #[allow(clippy::single_char_pattern)]
 mod tests {
-  use std::{ffi::OsStr, fmt::Write, fs::File, io, path::{Path, PathBuf}};
+  use std::{
+    ffi::OsStr,
+    fmt::Write,
+    fs::File,
+    io,
+    path::{Path, PathBuf},
+  };
 
   use ratatui::{backend::TestBackend, buffer::Buffer};
 

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -249,7 +249,7 @@ impl<'a> Widget for Calendar<'a> {
 
 impl<'a> Calendar<'a> {
   fn generate_month_names() -> [&'a str; 12] {
-    let month_names = [
+    [
       Month::January.name(),
       Month::February.name(),
       Month::March.name(),
@@ -262,7 +262,6 @@ impl<'a> Calendar<'a> {
       Month::October.name(),
       Month::November.name(),
       Month::December.name(),
-    ];
-    month_names
+    ]
   }
 }


### PR DESCRIPTION
Addresses #545.

See my [comment](https://github.com/kdheepak/taskwarrior-tui/issues/545#issuecomment-2024299278) on the issue for additional details.

I chose to drop Support for Taskwarrior v2.X.
This should avoid, while not technically necessary, ugly version specific fixes in the code, if significant differences between v2.X and v3.X surface.