### PR TITLE
fix: parse `shortcut.0` binding

### DIFF
--- a/docs/configuration/advanced.md
+++ b/docs/configuration/advanced.md
@@ -72,7 +72,7 @@ To make a file executable:
 1. Run `chmod +x /path/to/script` to modify the executable flag.
 2. Add `#!/usr/bin/env bash`, `#!/usr/bin/env python` or whatever is appropriate for your script.
 
-By default, keys `1`-`9` are available to run shortcuts.
+By default, keys `0`-`9` are available to run shortcuts.
 
 When you hit the shortcut, the script will be executed with the `selected_tasks_uuid` as an
 argument:
@@ -88,7 +88,7 @@ in `~/.config/taskwarrior-tui/shortcut-scripts/add-personal-tag.sh` :
 task rc.bulk=0 rc.confirmation=off rc.dependency.confirmation=off rc.recurrence.confirmation=off "$@" modify +personal
 ```
 
-By default, shortcuts are linked to the `1-9` number row keys. They can be customized as any other
+By default, shortcuts are linked to the `0-9` number row keys. They can be customized as any other
 keys through `uda.taskwarrior-tui.keyconfig.shortcut1=<key>`. For example:
 
 ```plaintext

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -58,7 +58,7 @@ Keybindings for task report:
 
     !: {string}                          - Custom shell command
 
-    1-9: {string}                        - Run user defined shortcuts
+    0-9: {string}                        - Run user defined shortcuts
 
     :: {task id}                         - Jump to task id
 

--- a/docs/taskwarrior-tui.1
+++ b/docs/taskwarrior-tui.1
@@ -123,7 +123,7 @@ scroll up task details - Scroll task details view up one line
 \f[V]!\f[R]
 {string} - Custom shell command
 .TP
-\f[V]1-9\f[R]
+\f[V]0-9\f[R]
 {string} - Run user defined shortcuts
 .TP
 \f[V]:\f[R]

--- a/docs/taskwarrior-tui.1.md
+++ b/docs/taskwarrior-tui.1.md
@@ -119,7 +119,7 @@ Ctrl-y
 `!`
 : {string}                          - Custom shell command
 
-`1-9`
+`0-9`
 : {string}                          - Run user defined shortcuts
 
 `:`

--- a/src/app.rs
+++ b/src/app.rs
@@ -2719,6 +2719,15 @@ impl TaskwarriorTui {
             self.update_completion_list();
           } else if input == KeyCode::Char(':') {
             self.mode = Mode::Tasks(Action::Jump);
+          } else if input == self.keyconfig.shortcut0 {
+            match self.task_shortcut(0).await {
+              Ok(_) => self.update(true).await?,
+              Err(e) => {
+                self.update(true).await?;
+                self.error = Some(e);
+                self.mode = Mode::Tasks(Action::Error);
+              }
+            }
           } else if input == self.keyconfig.shortcut1 {
             match self.task_shortcut(1).await {
               Ok(_) => self.update(true).await?,


### PR DESCRIPTION
Hi, so in the ReadMe there is an example binding for `shortcut.0` but when I tried it, it did not work. 
https://github.com/kdheepak/taskwarrior-tui/blob/4902ecdb34c549ed917635cce13148c13ac46106/README.md?plain=1#L122

I couldn't find it in the code either, so I guess it was just forgotten? 
Looking at line 251, I think the intended range is 0 to 9 even though the documentation and other places mention 1-9. 

https://github.com/kdheepak/taskwarrior-tui/blob/4902ecdb34c549ed917635cce13148c13ac46106/src/config.rs#L249-L257

This PR adds the missing logic to react to `shortcut.0` and I tried to find the places in the documentation to update it to say 0-9 instead of 1-9.

I can compile and run it and setting `shortcuts.0=task sync` syncs as expected. 
`cargo test` passes, too.
 