### PR TITLE
chore: release v0.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.2](https://github.com/kdheepak/taskwarrior-tui/compare/v0.26.1...v0.26.2) - 2024-05-12
+
+### Added
+- Add task duplicate
+- Add scheduled
+- Add scheduled countdown
+- Add recur to autocomplete options
+
+### Other
+- fix clippy issues
+- Update release-plz.yml with token
+
 ## [0.26.1](https://github.com/kdheepak/taskwarrior-tui/compare/v0.26.0...v0.26.1) - 2024-05-12
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "taskwarrior-tui"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "anyhow",
  "better-panic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskwarrior-tui"
-version = "0.26.1"
+version = "0.26.2"
 license = "MIT"
 description = "A Taskwarrior Terminal User Interface"
 repository = "https://github.com/kdheepak/taskwarrior-tui/"


### PR DESCRIPTION
## 🤖 New release
* `taskwarrior-tui`: 0.26.1 -> 0.26.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.2](https://github.com/kdheepak/taskwarrior-tui/compare/v0.26.1...v0.26.2) - 2024-05-12

### Added
- Add task duplicate
- Add scheduled
- Add scheduled countdown
- Add recur to autocomplete options

### Other
- fix clippy issues
- Update release-plz.yml with token
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).