### PR TITLE
chore: release v0.26.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.4](https://github.com/kdheepak/taskwarrior-tui/compare/v0.26.3...v0.26.4) - 2024-11-14
+
+### Added
+
+- Add code coverage to CI
+- Cache taskwarrior compilation
+- Build taskwarrior CI against stable
+
+### Fixed
+
+- Disable broken MacOS compression
+- Append target for unique artifact names
+- Update the upload-artifacts due to deprecation of v2
+- Deprecation warning
+
+### Other
+
+- Add us as Co-Maintainers ([#606](https://github.com/kdheepak/taskwarrior-tui/pull/606))
+- Apply clippy lint
+- Merge build workflows
+- Modernize CI/CD components
+- Use config for selection mark/unmark symbols ([#594](https://github.com/kdheepak/taskwarrior-tui/pull/594))
+- *(deps)* bump the cargo-dependencies group with 4 updates ([#584](https://github.com/kdheepak/taskwarrior-tui/pull/584))
+- *(deps)* bump tokio from 1.37.0 to 1.38.0 in the cargo-dependencies group ([#582](https://github.com/kdheepak/taskwarrior-tui/pull/582))
+- *(deps)* bump the cargo-dependencies group with 3 updates ([#580](https://github.com/kdheepak/taskwarrior-tui/pull/580))
+- Update taskwarrior-tui.bash
+- *(deps)* bump the cargo-dependencies group across 1 directory with 20 updates ([#573](https://github.com/kdheepak/taskwarrior-tui/pull/573))
+- *(deps)* Bump to ratatui v0.26
+- *(deps)* bump actions/checkout from 2 to 4 ([#569](https://github.com/kdheepak/taskwarrior-tui/pull/569))
+- *(deps)* bump peaceiris/actions-gh-pages from 3 to 4 ([#568](https://github.com/kdheepak/taskwarrior-tui/pull/568))
+- *(deps)* bump actions/setup-python from 1 to 5 ([#566](https://github.com/kdheepak/taskwarrior-tui/pull/566))
+- *(deps)* bump actions/setup-python from 1 to 5
+- Add dependabot.yml
+
 ## [0.26.3](https://github.com/kdheepak/taskwarrior-tui/compare/v0.26.2...v0.26.3) - 2024-05-12
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "taskwarrior-tui"
-version = "0.26.3"
+version = "0.26.4"
 dependencies = [
  "anyhow",
  "better-panic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskwarrior-tui"
-version = "0.26.3"
+version = "0.26.4"
 license = "MIT"
 description = "A Taskwarrior Terminal User Interface"
 repository = "https://github.com/kdheepak/taskwarrior-tui/"


### PR DESCRIPTION
## 🤖 New release
* `taskwarrior-tui`: 0.26.3 -> 0.26.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.4](https://github.com/kdheepak/taskwarrior-tui/compare/v0.26.3...v0.26.4) - 2024-11-14

### Added

- Add code coverage to CI
- Cache taskwarrior compilation
- Build taskwarrior CI against stable

### Fixed

- Disable broken MacOS compression
- Append target for unique artifact names
- Update the upload-artifacts due to deprecation of v2
- Deprecation warning

### Other

- Add us as Co-Maintainers ([#606](https://github.com/kdheepak/taskwarrior-tui/pull/606))
- Apply clippy lint
- Merge build workflows
- Modernize CI/CD components
- Use config for selection mark/unmark symbols ([#594](https://github.com/kdheepak/taskwarrior-tui/pull/594))
- *(deps)* bump the cargo-dependencies group with 4 updates ([#584](https://github.com/kdheepak/taskwarrior-tui/pull/584))
- *(deps)* bump tokio from 1.37.0 to 1.38.0 in the cargo-dependencies group ([#582](https://github.com/kdheepak/taskwarrior-tui/pull/582))
- *(deps)* bump the cargo-dependencies group with 3 updates ([#580](https://github.com/kdheepak/taskwarrior-tui/pull/580))
- Update taskwarrior-tui.bash
- *(deps)* bump the cargo-dependencies group across 1 directory with 20 updates ([#573](https://github.com/kdheepak/taskwarrior-tui/pull/573))
- *(deps)* Bump to ratatui v0.26
- *(deps)* bump actions/checkout from 2 to 4 ([#569](https://github.com/kdheepak/taskwarrior-tui/pull/569))
- *(deps)* bump peaceiris/actions-gh-pages from 3 to 4 ([#568](https://github.com/kdheepak/taskwarrior-tui/pull/568))
- *(deps)* bump actions/setup-python from 1 to 5 ([#566](https://github.com/kdheepak/taskwarrior-tui/pull/566))
- *(deps)* bump actions/setup-python from 1 to 5
- Add dependabot.yml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).