### PR TITLE
Use config for selection mark/unmark symbols

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1251,6 +1251,8 @@ impl TaskwarriorTui {
       )
       .highlight_style(highlight_style)
       .highlight_symbol(&self.config.uda_selection_indicator)
+      .mark_highlight_symbol(&self.config.uda_mark_highlight_indicator)
+      .unmark_highlight_symbol(&self.config.uda_unmark_highlight_indicator)
       .mark_symbol(&self.config.uda_mark_indicator)
       .unmark_symbol(&self.config.uda_unmark_indicator)
       .widths(&constraints);

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,8 @@ pub struct Config {
   pub uda_task_report_looping: bool,
   pub uda_task_report_jump_to_task_on_add: bool,
   pub uda_selection_indicator: String,
+  pub uda_mark_highlight_indicator: String,
+  pub uda_unmark_highlight_indicator: String,
   pub uda_mark_indicator: String,
   pub uda_unmark_indicator: String,
   pub uda_scrollbar_indicator: String,
@@ -133,6 +135,8 @@ impl Config {
     let uda_task_report_looping = Self::get_uda_task_report_looping(data);
     let uda_task_report_jump_to_task_on_add = Self::get_uda_task_report_jump_to_task_on_add(data);
     let uda_selection_indicator = Self::get_uda_selection_indicator(data);
+    let uda_mark_highlight_indicator = Self::get_uda_mark_highlight_indicator(data);
+    let uda_unmark_highlight_indicator = Self::get_uda_unmark_highlight_indicator(data);
     let uda_mark_indicator = Self::get_uda_mark_indicator(data);
     let uda_unmark_indicator = Self::get_uda_unmark_indicator(data);
     let uda_scrollbar_indicator = Self::get_uda_scrollbar_indicator(data);
@@ -198,6 +202,8 @@ impl Config {
       uda_task_report_looping,
       uda_task_report_jump_to_task_on_add,
       uda_selection_indicator,
+      uda_mark_highlight_indicator,
+      uda_unmark_highlight_indicator,
       uda_mark_indicator,
       uda_unmark_indicator,
       uda_scrollbar_indicator,


### PR DESCRIPTION
Configuration items `uda.taskwarrior-tui.{un,}mark-selection.indicator` are not used when rendering the corresponding symbols in the main table.

Example configuration:

```
uda.taskwarrior-tui.selection.indicator=a
uda.taskwarrior-tui.mark.indicator=b
uda.taskwarrior-tui.unmark.indicator=c
uda.taskwarrior-tui.mark-selection.indicator=x
uda.taskwarrior-tui.unmark-selection.indicator=y
```

The result [looks like this](https://asciinema.org/a/0IohG6kPrsAUcOQUsa79TbfYq). `x` and `y` are nowhere to be seen.

With this fix it [looks like this](https://asciinema.org/a/38GpyBZLoSPO1xhN3e2VCQWnR).


