### PR TITLE
Fix GithubCI by version bumping deprecated workflow actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
             shasum -a 256 taskwarrior-tui-${{ matrix.target }}.tar.gz > taskwarrior-tui-${{ matrix.target }}.sha256
           fi
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: taskwarrior-tui
           path: target/${{ matrix.target }}/release/taskwarrior-tui-${{ matrix.target }}.tar.gz

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -91,7 +91,7 @@ jobs:
             shasum -a 256 taskwarrior-tui-${{ matrix.target }}.tar.gz > taskwarrior-tui-${{ matrix.target }}.sha256
           fi
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: taskwarrior-tui
           path: target/${{ matrix.target }}/release/taskwarrior-tui-${{ matrix.target }}.tar.gz
@@ -131,7 +131,7 @@ jobs:
       - name: Build deb package
         run: cargo deb -p taskwarrior-tui -o target/debian/taskwarrior-tui.deb
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: taskwarrior-tui
           path: target/debian/taskwarrior-tui.deb
@@ -161,7 +161,7 @@ jobs:
       - name: Build rpm package
         run: cargo rpm build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: taskwarrior-tui
           path: target/release/rpmbuild/RPMS/x86_64/taskwarrior-tui-*.x86_64.rpm


### PR DESCRIPTION
Closes #601.
See #601 for a linked example failure log.