### PR TITLE
chore: Update zsh completion

### DIFF
--- a/completions/_taskwarrior-tui
+++ b/completions/_taskwarrior-tui
@@ -14,7 +14,7 @@ _taskwarrior-tui() {
     fi
 
     local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
+    _arguments "${_arguments_options[@]}" : \
 '-d+[Sets the data folder for taskwarrior-tui]:FOLDER: ' \
 '--data=[Sets the data folder for taskwarrior-tui]:FOLDER: ' \
 '-c+[Sets the config folder for taskwarrior-tui (currently not used)]:FOLDER: ' \


### PR DESCRIPTION
This is the currently generated zsh completion from the `build.rs`
script.

I noticed this while looking at the project.
Not sure if this is actually the more correct completion, but this is what the build script generates.