### PR TITLE
chore: Implement current clippy fixes

### DIFF
--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -92,7 +92,7 @@ impl<'a> Calendar<'a> {
   }
 }
 
-impl<'a> Widget for Calendar<'a> {
+impl Widget for Calendar<'_> {
   fn render(mut self, area: Rect, buf: &mut Buffer) {
     let month_names = Self::generate_month_names();
     buf.set_style(area, self.style);

--- a/src/history.rs
+++ b/src/history.rs
@@ -97,7 +97,7 @@ impl HistoryContext {
     };
 
     log::debug!("Using history index = {} for searching", history_index);
-    return if let Some(history_index) = self.history.starts_with(buf, history_index, dir).unwrap() {
+    if let Some(history_index) = self.history.starts_with(buf, history_index, dir).unwrap() {
       log::debug!("Found index {:?}", history_index);
       log::debug!("Previous index {:?}", self.history_index);
       self.history_index = Some(history_index.idx);
@@ -116,7 +116,7 @@ impl HistoryContext {
     } else {
       log::debug!("History index = {}. Found no match.", history_index);
       None
-    };
+    }
   }
 
   pub fn add(&mut self, buf: &str) {

--- a/src/pane/project.rs
+++ b/src/pane/project.rs
@@ -112,7 +112,7 @@ impl ProjectsState {
 
   pub fn last_line(&self, line: &str) -> bool {
     let words = line.trim().split(' ').map(|s| s.trim()).collect::<Vec<&str>>();
-    return words.len() == 2 && words[0].chars().map(|c| c.is_numeric()).all(|b| b) && (words[1] == "project" || words[1] == "projects");
+    words.len() == 2 && words[0].chars().all(|c| c.is_numeric()) && (words[1] == "project" || words[1] == "projects")
   }
 
   pub fn update_data(&mut self) -> Result<()> {

--- a/src/table.rs
+++ b/src/table.rs
@@ -297,7 +297,7 @@ where
   }
 }
 
-impl<'a, H, D, R> StatefulWidget for Table<'a, H, R>
+impl<H, D, R> StatefulWidget for Table<'_, H, R>
 where
   H: Iterator,
   H::Item: Display,
@@ -521,7 +521,7 @@ where
   }
 }
 
-impl<'a, H, D, R> Widget for Table<'a, H, R>
+impl<H, D, R> Widget for Table<'_, H, R>
 where
   H: Iterator,
   H::Item: Display,


### PR DESCRIPTION
Since the ci is run against the current stable toolchain, this fixes clippy warnings for: `rustc 1.84.1`.