### PR TITLE
feat: help screen shows user keybindings

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -1,5 +1,11 @@
 # Default Keybindings
 
+> [!NOTE]
+> If any bindings are changed in the `.taskrc`, the built-in help menu will show
+> them instead of the defaults. Please see
+> [configuration/keys](./configuration/keys.md) for details on custom
+> keybindings.
+
 Keybindings:
 
     Esc:                                 - Exit current action

--- a/src/app.rs
+++ b/src/app.rs
@@ -275,7 +275,7 @@ impl TaskwarriorTui {
       config: c,
       task_report_table: TaskReportTable::new(&data, report)?,
       calendar_year: Local::now().year(),
-      help_popup: Help::new(),
+      help_popup: Help::new(&kc),
       last_export: None,
       keyconfig: kc,
       terminal_width: w,
@@ -1780,7 +1780,10 @@ impl TaskwarriorTui {
             Ok(o) => {
               let output = String::from_utf8_lossy(&o.stdout);
               if !output.is_empty() {
-                Err(format!("Shell command `{}` ran successfully but printed the following output:\n\n{}\n\nSuppress output of shell commands to prevent the error prompt from showing up.", shell, output))
+                Err(format!(
+                  "Shell command `{}` ran successfully but printed the following output:\n\n{}\n\nSuppress output of shell commands to prevent the error prompt from showing up.",
+                  shell, output
+                ))
               } else {
                 Ok(())
               }
@@ -4733,7 +4736,7 @@ mod tests {
   async fn test_draw_help_popup() {
     let mut expected = Buffer::with_lines(vec![
       "╭Help──────────────────────────────────╮",
-      "│# Default Keybindings                 │",
+      "│# Keybindings                         │",
       "│                                      │",
       "│Keybindings:                          │",
       "│                                      │",
@@ -4743,7 +4746,7 @@ mod tests {
       "│                                      │",
       "│    [: Previous view                  │",
       "╰──────────────────────────────────────╯",
-      "9% ─────────────────────────────────────",
+      "8% ─────────────────────────────────────",
     ]);
 
     for i in 1..=4 {
@@ -4752,7 +4755,6 @@ mod tests {
     }
     expected.get_mut(3, 11).set_style(Style::default().fg(Color::Gray));
     expected.get_mut(4, 11).set_style(Style::default().fg(Color::Gray));
-    expected.get_mut(5, 11).set_style(Style::default().fg(Color::Gray));
 
     let mut app = TaskwarriorTui::new("next", false).await.unwrap();
 

--- a/src/help.rs
+++ b/src/help.rs
@@ -8,33 +8,110 @@ use ratatui::{
   widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget},
 };
 
-const TEXT: &str = include_str!("../docs/keybindings.md");
+const TEMPLATE: &str = include_str!("help.tmpl");
+
+use crate::{event::KeyCode, keyconfig::KeyConfig};
 
 pub struct Help {
   pub title: String,
   pub scroll: u16,
   pub text_height: usize,
+  /// Dynamically generated contents of the Help screen
+  pub text: String,
+}
+
+/// Returns the configured KeyCode for a given name string
+fn keycode_for(name: &str, kc: &KeyConfig) -> KeyCode {
+  match name {
+    "quit" => kc.quit,
+    "next_tab" => kc.next_tab,
+    "previous_tab" => kc.previous_tab,
+    "filter" => kc.filter,
+    "add" => kc.add,
+    "done" => kc.done,
+    "edit" => kc.edit,
+    "duplicate" => kc.duplicate,
+    "down" => kc.down,
+    "up" => kc.up,
+    "page_down" => kc.page_down,
+    "page_up" => kc.page_up,
+    "go_to_top" => kc.go_to_top,
+    "go_to_bottom" => kc.go_to_bottom,
+    "log" => kc.log,
+    "modify" => kc.modify,
+    "start_stop" => kc.start_stop,
+    "quick_tag" => kc.quick_tag,
+    "undo" => kc.undo,
+    "select" => kc.select,
+    "select_all" => kc.select_all,
+    "delete" => kc.delete,
+    "zoom" => kc.zoom,
+    "annotate" => kc.annotate,
+    "shell" => kc.shell,
+    "shortcut0" => kc.shortcut0,
+    "shortcut1" => kc.shortcut1,
+    "shortcut2" => kc.shortcut2,
+    "shortcut3" => kc.shortcut3,
+    "shortcut4" => kc.shortcut4,
+    "shortcut5" => kc.shortcut5,
+    "shortcut6" => kc.shortcut6,
+    "shortcut7" => kc.shortcut7,
+    "shortcut8" => kc.shortcut8,
+    "context_menu" => kc.context_menu,
+    "help" => kc.help,
+    _ => KeyCode::Null,
+  }
+}
+
+/// Generates the Help text from the template based on the current
+/// key configuration. Every substring `{{token}}` in the template
+/// is replaced with the character held by `kc.token`.
+fn render_help(kc: &KeyConfig, tmpl: &str) -> String {
+  // NOTE: assumes KeyCode is always a single char (which is currently the case)
+  // this function MUST be updated if that ever changes
+  let mut out = String::with_capacity(tmpl.len());
+  let mut i = 0;
+  while let Some(start) = tmpl[i..].find("{{") {
+    let s = i + start;
+    out.push_str(&tmpl[i..s]);
+    if let Some(end) = tmpl[s + 2..].find("}}") {
+      let e = s + 2 + end;
+      let name = &tmpl[s + 2..e];
+      if let KeyCode::Char(c) = keycode_for(name, kc) {
+        out.push(c);
+      }
+      i = e + 2;
+      continue;
+    }
+    break;
+  }
+  out.push_str(&tmpl[i..]);
+  out
 }
 
 impl Help {
-  pub fn new() -> Self {
+  pub fn new(keyconfig: &KeyConfig) -> Self {
+    let text = render_help(keyconfig, TEMPLATE);
+    let text_height = text.lines().count();
+
     Self {
       title: "Help".to_string(),
       scroll: 0,
-      text_height: TEXT.lines().count(),
+      text_height,
+      text,
     }
   }
 }
 
 impl Default for Help {
   fn default() -> Self {
-    Self::new()
+    Self::new(&KeyConfig::default())
   }
 }
 
 impl Widget for &Help {
   fn render(self, area: Rect, buf: &mut Buffer) {
-    let text: Vec<Line> = TEXT.lines().map(|line| Line::from(format!("{}\n", line))).collect();
+    let text: Vec<Line> = self.text.lines().map(|l| Line::from(l.to_owned())).collect();
     Paragraph::new(text)
       .block(
         Block::default()

--- a/src/help.tmpl
+++ b/src/help.tmpl
@@ -1,0 +1,139 @@
+# Keybindings
+
+Keybindings:
+
+    Esc:                                 - Exit current action
+
+    {{next_tab}}: Next view                         - Go to next view
+
+    {{previous_tab}}: Previous view                     - Go to previous view
+
+Keybindings for task report:
+
+    {{filter}}: task {string}                     - Filter task report
+
+    {{add}}: task add {string}                 - Add new task
+
+    {{done}}: task {selected} done              - Mark task as done
+
+    {{edit}}: task {selected} edit              - Open selected task in editor
+
+    {{duplicate}}: task {selected} duplicate         - Duplicate tasks
+
+    {{down}}: {selected+=1}                     - Move down in task report
+
+    {{up}}: {selected-=1}                     - Move up in task report
+
+    {{page_down}}: {selected+=pageheight}            - Move page down in task report
+
+    {{page_up}}: {selected-=pageheight}            - Move page up in task report
+
+    {{go_to_top}}: {selected=first}                  - Go to top
+
+    {{go_to_bottom}}: {selected=last}                   - Go to bottom
+
+    {{log}}: task log {string}                 - Log new task
+
+    {{modify}}: task {selected} modify {string}   - Modify selected task
+
+    {{quit}}: exit                              - Quit
+
+    {{start_stop}}: task {selected} start/stop        - Toggle start and stop
+
+    {{quick_tag}}: task {selected} +{tag}/-{tag}     - Toggle {uda.taskwarrior-tui.quick-tag.name} (default: `next`)
+
+    {{undo}}: task undo                         - Undo
+
+    {{select}}: {toggle mark on selected}         - Toggle mark on selected
+
+    {{select_all}}: {toggle marks on all tasks}       - Toggle marks on all tasks in current filter report
+
+    {{delete}}: task {selected} delete            - Delete
+
+    {{zoom}}: toggle task info                  - Toggle task info view
+
+    {{annotate}}: task {selected} annotate {string} - Annotate current task
+
+    Ctrl-e: scroll down task details     - Scroll task details view down one line
+
+    Ctrl-y: scroll up task details       - Scroll task details view up one line
+
+    {{shell}}: {string}                          - Custom shell command
+
+    {{shortcut0}}: {string}                        - Run user defined shortcut 0
+
+    {{shortcut1}}: {string}                        - Run user defined shortcut 1
+
+    {{shortcut2}}: {string}                        - Run user defined shortcut 2
+
+    {{shortcut3}}: {string}                        - Run user defined shortcut 3
+
+    {{shortcut4}}: {string}                        - Run user defined shortcut 4
+
+    {{shortcut5}}: {string}                        - Run user defined shortcut 5
+
+    {{shortcut6}}: {string}                        - Run user defined shortcut 6
+
+    {{shortcut7}}: {string}                        - Run user defined shortcut 7
+
+    {{shortcut8}}: {string}                        - Run user defined shortcut 8
+
+    :: {task id}                         - Jump to task id
+
+    {{context_menu}}: context switcher menu             - Open context switcher menu
+
+    {{help}}: help                              - Help menu
+
+Keybindings for filter / command prompt:
+
+    Ctrl + f | Right: move forward       - Move forward one character
+
+    Ctrl + b | Left: move backward       - Move backward one character
+
+    Ctrl + h | Backspace: backspace      - Delete one character back
+
+    Ctrl + d | Delete: delete            - Delete one character forward
+
+    Ctrl + a | Home: home                - Go to the beginning of line
+
+    Ctrl + e | End: end                  - Go to the end of line
+
+    Ctrl + k: delete to end              - Delete to the end of line
+
+    Ctrl + u: delete to beginning        - Delete to the beginning of line
+
+    Ctrl + w: delete previous word       - Delete previous word
+
+    Alt + d: delete next word            - Delete next word
+
+    Alt + b: move to previous word       - Move to previous word
+
+    Alt + f: move to next word           - Move to next word
+
+    Alt + t: transpose words             - Transpose words
+
+    Up: scroll history                   - Go backward in history matching from beginning of line to cursor
+
+    Down: scroll history                 - Go forward in history matching from beginning of line to cursor
+
+    TAB | Ctrl + n: tab complete         - Open tab completion and selection first element OR cycle to next element
+
+    BACKTAB | Ctrl + p: tab complete     - Cycle to previous element
+
+Keybindings for context switcher:
+
+    {{down}}: {selected+=1}                     - Move forward a context
+
+    {{up}}: {selected-=1}                     - Move back a context
+
+    Enter: task context {selected}       - Select highlighted context
+
+Keybindings for calendar:
+
+    {{down}}: {selected+=1}                     - Move forward a year in calendar
+
+    {{up}}: {selected-=1}                     - Move back a year in calendar
+
+    {{page_down}}: {selected+=10}                    - Move forward a decade in calendar
+
+    {{page_up}}: {selected-=10}                    - Move back a decade in calendar


### PR DESCRIPTION
The new help screen shows the bindings currently set by the user, not the defaults. The new src/help.tmpl file is processed s.t. each occurrence of `{{foo}}` is replaced with the current value of `KeyConfig.foo`. Currently, the help text is only computed once at startup. It's also assumed that keys are always single character.

See below an example of the new help menu with some changed binds:

<img width="747" height="913" alt="image" src="https://github.com/user-attachments/assets/027b8cbf-cc28-460c-830d-bc7e91f6b47c" />

I also updated the test to match the new output.
