### PR TITLE
chore(setup): add just recipes for local test data

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -1,2 +1,13 @@
+# deletes test data if it exists
 clean:
-    rm -rf tests/data/.task tests/data/.config
+    [ -d tests/data ] && rm -rf tests/data || true
+
+# clones the test data expected by cargo test
+setup-tests: clean
+    mkdir -p tests
+    git clone https://github.com/kdheepak/taskwarrior-testdata tests/data
+
+# run tests ensuring fresh test data each time
+test: setup-tests
+    cargo test
+


### PR DESCRIPTION
Replaced `clean` with a version that removes `tests/data` if it exists, and does nothing (but won't fail) if it doesn't. Also added a `setup-tests` recipe that clones the test-data repo into `tests/data`. The new `test` recipe calls `setup-tests` as a dependency, ensuring that a fresh and correct test data directory is present every time.

These changes will make it easier for contributors to run tests with the same test data used by CI, helping them catch test failures locally instead of waiting for CI each time.