### PR TITLE
feat(ui): add full support for colors like taskwarrior

### DIFF
--- a/docs/configuration/advanced.md
+++ b/docs/configuration/advanced.md
@@ -43,6 +43,11 @@ uda.taskwarrior-tui.task-report.auto-insert-double-quotes-on-log=true
 uda.taskwarrior-tui.task-report.reset-filter-on-esc=true
 uda.taskwarrior-tui.context-menu.select-on-move=false
 uda.taskwarrior-tui.tabs.change-focus-rotate=false
+# UI chrome styles (support all Taskwarrior color formats)
+uda.taskwarrior-tui.style.title=         # default: LightCyan foreground
+uda.taskwarrior-tui.style.title.border=  # default: White foreground
+uda.taskwarrior-tui.style.help.gauge=    # default: Gray foreground
+uda.taskwarrior-tui.style.command.error= # default: Red foreground
 ```
 
 The `uda.taskwarrior-tui.task-report.next.filter` variable defines the default view at program

--- a/docs/configuration/colors.md
+++ b/docs/configuration/colors.md
@@ -1,6 +1,6 @@
 # Color configuration
 
-`taskwarrior-tui` reads values from your `taskwarrior`'s `taskrc` file (default: `~/.taskrc`).
+`taskwarrior-tui` reads color values from your taskwarrior `taskrc` file (default: `~/.taskrc`).
 
 ![](https://user-images.githubusercontent.com/1813121/96684390-bf173e80-1338-11eb-971c-ae64233d142e.png)
 
@@ -24,3 +24,105 @@ color.blocking
 color.recurring
 color.tagged
 ```
+
+## Color formats
+
+All color formats supported by Taskwarrior are recognized:
+
+### Named colors (16-color)
+
+```
+black  red  green  yellow  blue  magenta  cyan  white
+```
+
+Use `on <color>` to set the background:
+
+```
+red on blue        # red foreground, blue background
+on yellow          # default foreground, yellow background
+```
+
+### High-intensity (bright) colors
+
+Use the `bright` prefix on backgrounds to get the high-intensity variant (terminal colors 8–15):
+
+```
+black on bright green    # bright green background
+white on bright black    # bright black (dark gray) background
+```
+
+### 256-color indexed
+
+Use `color0` through `color255` to access the full 256-color palette:
+
+```
+color196           # bright red
+color60 on color60 # foreground and background using index 60
+```
+
+### Grayscale ramp
+
+Use `gray0` through `gray23` (or `grey0`–`grey23`) to access the 24-step grayscale ramp
+(terminal colors 232–255):
+
+```
+gray5              # dark gray (Color::Indexed(237))
+white on gray10    # white text on mid-gray background
+```
+
+### RGB color cube
+
+Use `rgbRGB` where R, G, B are each a digit from 0 to 5 to address the 6×6×6 color cube
+(terminal colors 16–231):
+
+```
+rgb500             # bright red  (Color::Indexed(196))
+rgb050             # bright green
+rgb005             # bright blue
+rgb444             # medium gray-ish
+```
+
+## Modifiers
+
+The following text modifiers can be combined with any color:
+
+| Modifier | Effect |
+|---|---|
+| `bold` | Bold text |
+| `underline` | Underlined text |
+| `inverse` | Swapped foreground/background |
+| `italic` | Italic text |
+| `strikethrough` | Strikethrough text |
+
+Multiple modifiers can be combined:
+
+```
+bold underline red on blue
+italic color111 on color60
+```
+
+## `bold` vs `bright`
+
+- `bold` is a **text attribute** — it makes text bold and uses the regular color index.
+- `bright` is a **color variant** — for backgrounds, it selects the high-intensity color (index + 8).
+
+```
+bold red           # regular red (#1) + bold attribute
+on bright red      # high-intensity red background (#9)
+bold on bright red # bold text + high-intensity red background
+```
+
+## Example: TokyoNight Moon theme
+
+```
+color.active=color111 on color60
+color.overdue=color203
+color.due.today=color215
+color.due=color111
+color.blocked=color245
+color.tagged=color141
+color.recurring=color147
+color.scheduled=color109
+```
+
+See [advanced configuration](advanced.md) for TUI-specific style keys.

--- a/src/app.rs
+++ b/src/app.rs
@@ -908,7 +908,7 @@ impl TaskwarriorTui {
 
     let gauge = LineGauge::default()
       .block(Block::default())
-      .filled_style(Style::default().fg(Color::Gray))
+      .filled_style(self.config.uda_style_help_gauge)
       .ratio(ratio);
 
     f.render_widget(gauge, chunks[1]);
@@ -1034,7 +1034,7 @@ impl TaskwarriorTui {
     // render command title
     let mut style = self.config.uda_style_command;
     if error.is_some() {
-      style = style.fg(Color::Red);
+      style = self.config.uda_style_command_error;
     };
     let title_spans = if let Some(subtitle) = title.1 {
       Line::from(vec![title.0, Span::from(" ["), subtitle, Span::from("]")])

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,10 @@ pub struct Config {
   pub uda_style_command: Style,
   pub uda_style_report_completion_pane: Style,
   pub uda_style_report_completion_pane_highlight: Style,
+  pub uda_style_title: Style,
+  pub uda_style_title_border: Style,
+  pub uda_style_help_gauge: Style,
+  pub uda_style_command_error: Style,
   pub uda_shortcuts: Vec<String>,
   pub uda_change_focus_rotate: bool,
   pub uda_background_process: String,
@@ -159,6 +163,10 @@ impl Config {
     let uda_style_context_active = Self::get_uda_style("context.active", data);
     let uda_style_report_completion_pane = Self::get_uda_style("report.completion-pane", data);
     let uda_style_report_completion_pane_highlight = Self::get_uda_style("report.completion-pane-highlight", data);
+    let uda_style_title = Self::get_uda_style("title", data);
+    let uda_style_title_border = Self::get_uda_style("title.border", data);
+    let uda_style_help_gauge = Self::get_uda_style("help.gauge", data);
+    let uda_style_command_error = Self::get_uda_style("command.error", data);
     let uda_shortcuts = Self::get_uda_shortcuts(data);
     let uda_background_process = Self::get_uda_background_process(data);
     let uda_background_process_period = Self::get_uda_background_process_period(data);
@@ -173,6 +181,10 @@ impl Config {
     let uda_style_report_completion_pane =
       uda_style_report_completion_pane.unwrap_or_else(|| Style::default().fg(Color::Black).bg(Color::Rgb(223, 223, 223)));
     let uda_style_report_completion_pane_highlight = uda_style_report_completion_pane_highlight.unwrap_or(uda_style_report_completion_pane);
+    let uda_style_title = uda_style_title.unwrap_or_else(|| Style::default().fg(Color::LightCyan));
+    let uda_style_title_border = uda_style_title_border.unwrap_or_else(|| Style::default().fg(Color::White));
+    let uda_style_help_gauge = uda_style_help_gauge.unwrap_or_else(|| Style::default().fg(Color::Gray));
+    let uda_style_command_error = uda_style_command_error.unwrap_or_else(|| Style::default().fg(Color::Red));
     let uda_quick_tag_name = Self::get_uda_quick_tag_name(data);
     let uda_tasklist_vertical = Self::get_uda_tasklist_vertical(data);
     let uda_task_report_prompt_on_undo = Self::get_uda_task_report_prompt_on_undo(data);
@@ -225,6 +237,10 @@ impl Config {
       uda_style_command,
       uda_style_report_completion_pane,
       uda_style_report_completion_pane_highlight,
+      uda_style_title,
+      uda_style_title_border,
+      uda_style_help_gauge,
+      uda_style_command_error,
       uda_style_report_scrollbar,
       uda_style_report_scrollbar_area,
       uda_shortcuts,
@@ -290,148 +306,146 @@ impl Config {
   }
 
   pub fn get_tcolor(line: &str) -> Style {
-    let (foreground, background) = line.split_at(line.to_lowercase().find("on ").unwrap_or(line.len()));
-    let (mut foreground, mut background) = (String::from(foreground), String::from(background));
-    background = background.replace("on ", "");
+    // Normalize spelling variants
+    let line = line.replace("grey", "gray");
+    let line = line.trim();
+
+    // Split on " on " to separate foreground from background.
+    // Also handle the background-only case where the string starts with "on ".
+    // We search case-insensitively but keep the original casing for parsing.
+    let lower = line.to_lowercase();
+    let (fg_raw, bg_raw) = if lower.starts_with("on ") {
+      // Background-only: "on blue", "on bright red", etc.
+      ("", &line[3..])
+    } else if let Some(pos) = lower.find(" on ") {
+      (&line[..pos], &line[pos + 4..])
+    } else {
+      (line, "")
+    };
+
     let mut modifiers = Modifier::empty();
-    if foreground.contains("bright") {
-      foreground = foreground.replace("bright ", "");
-      background = background.replace("bright ", "");
-      background.insert_str(0, "bright ");
-    }
-    foreground = foreground.replace("grey", "gray");
-    background = background.replace("grey", "gray");
-    if foreground.contains("underline") {
-      modifiers |= Modifier::UNDERLINED;
-    }
-    let foreground = foreground.replace("underline ", "");
-    // TODO: use bold, bright boolean flags
-    if foreground.contains("bold") {
+
+    // Parse modifiers from the foreground portion (taskwarrior puts them before "on")
+    if fg_raw.contains("bold") {
       modifiers |= Modifier::BOLD;
     }
-    // let foreground = foreground.replace("bold ", "");
-    if foreground.contains("inverse") {
+    if fg_raw.contains("underline") {
+      modifiers |= Modifier::UNDERLINED;
+    }
+    if fg_raw.contains("inverse") {
       modifiers |= Modifier::REVERSED;
     }
-    let foreground = foreground.replace("inverse ", "");
+    if fg_raw.contains("italic") {
+      modifiers |= Modifier::ITALIC;
+    }
+    if fg_raw.contains("strikethrough") {
+      modifiers |= Modifier::CROSSED_OUT;
+    }
+
+    // Strip all modifier keywords from the foreground color name
+    let fg_color = fg_raw
+      .replace("bold ", "")
+      .replace("underline ", "")
+      .replace("inverse ", "")
+      .replace("italic ", "")
+      .replace("strikethrough ", "");
+    let fg_color = fg_color.trim();
+
+    // Strip leading "bright " from background (taskwarrior uses "on bright red")
+    let bg_color = bg_raw.trim_start_matches("bright ").trim();
+    let bg_is_bright = bg_raw.trim_start().starts_with("bright ");
+
     let mut style = Style::default();
-    if let Some(fg) = Self::get_color_foreground(foreground.as_str()) {
+    if let Some(fg) = Self::parse_color(fg_color) {
       style = style.fg(fg);
     }
-    if let Some(bg) = Self::get_color_background(background.as_str()) {
+    if let Some(bg) = Self::parse_color_bg(bg_color, bg_is_bright) {
       style = style.bg(bg);
     }
     style = style.add_modifier(modifiers);
     style
   }
 
-  fn get_color_foreground(s: &str) -> Option<Color> {
-    let s = s.trim_start();
-    let s = s.trim_end();
-    if s.contains("color") {
-      let c = s.trim_start_matches("color").parse::<u8>().unwrap_or_default();
-      Some(Color::Indexed(c))
-    } else if s.contains("gray") {
-      let c = 232 + s.trim_start_matches("gray").parse::<u8>().unwrap_or_default();
-      Some(Color::Indexed(c))
-    } else if s.contains("rgb") {
-      let red = (s.as_bytes()[3] as char).to_digit(10).unwrap_or_default() as u8;
-      let green = (s.as_bytes()[4] as char).to_digit(10).unwrap_or_default() as u8;
-      let blue = (s.as_bytes()[5] as char).to_digit(10).unwrap_or_default() as u8;
-      let c = 16 + red * 36 + green * 6 + blue;
-      Some(Color::Indexed(c))
-    } else if s == "bold black" {
-      Some(Color::Indexed(8))
-    } else if s == "bold red" {
-      Some(Color::Indexed(9))
-    } else if s == "bold green" {
-      Some(Color::Indexed(10))
-    } else if s == "bold yellow" {
-      Some(Color::Indexed(11))
-    } else if s == "bold blue" {
-      Some(Color::Indexed(12))
-    } else if s == "bold magenta" {
-      Some(Color::Indexed(13))
-    } else if s == "bold cyan" {
-      Some(Color::Indexed(14))
-    } else if s == "bold white" {
-      Some(Color::Indexed(15))
-    } else if s == "black" {
-      Some(Color::Indexed(0))
-    } else if s == "red" {
-      Some(Color::Indexed(1))
-    } else if s == "green" {
-      Some(Color::Indexed(2))
-    } else if s == "yellow" {
-      Some(Color::Indexed(3))
-    } else if s == "blue" {
-      Some(Color::Indexed(4))
-    } else if s == "magenta" {
-      Some(Color::Indexed(5))
-    } else if s == "cyan" {
-      Some(Color::Indexed(6))
-    } else if s == "white" {
-      Some(Color::Indexed(7))
-    } else {
-      None
+  /// Parse a color name into a ratatui Color.
+  ///
+  /// Supports all Taskwarrior color formats:
+  /// - Named 16-color: `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`
+  /// - High-intensity variants: `bright <name>` or `bold <name>` -> indices 8-15
+  /// - 256-color indexed: `color0` through `color255`
+  /// - Grayscale ramp: `gray0` through `gray23` (also `grey` spelling)
+  /// - RGB color cube: `rgb000` through `rgb555` (6x6x6)
+  fn parse_color(s: &str) -> Option<Color> {
+    let s = s.trim();
+    if s.is_empty() {
+      return None;
     }
+
+    // High-intensity named colors: "bright <name>" or "bold <name>"
+    let base = if let Some(rest) = s.strip_prefix("bright ") {
+      let idx = Self::named_color_index(rest.trim())?;
+      return Some(Color::Indexed(idx + 8));
+    } else if let Some(rest) = s.strip_prefix("bold ") {
+      let idx = Self::named_color_index(rest.trim())?;
+      return Some(Color::Indexed(idx + 8));
+    } else {
+      s
+    };
+
+    // 256-color indexed: "colorN"
+    if let Some(rest) = base.strip_prefix("color") {
+      let n = rest.parse::<u8>().ok()?;
+      return Some(Color::Indexed(n));
+    }
+
+    // Grayscale ramp: "grayN" (gray0-gray23 -> indexed 232-255)
+    if let Some(rest) = base.strip_prefix("gray") {
+      let n = rest.parse::<u8>().ok()?;
+      return Some(Color::Indexed(232 + n));
+    }
+
+    // RGB color cube: "rgbRGB" where each digit is 0-5
+    if let Some(rest) = base.strip_prefix("rgb") {
+      let bytes = rest.as_bytes();
+      if bytes.len() >= 3 {
+        let r = (bytes[0] as char).to_digit(6)? as u8;
+        let g = (bytes[1] as char).to_digit(6)? as u8;
+        let b = (bytes[2] as char).to_digit(6)? as u8;
+        return Some(Color::Indexed(16 + r * 36 + g * 6 + b));
+      }
+      return None;
+    }
+
+    // Plain named color
+    Self::named_color_index(base).map(Color::Indexed)
   }
 
-  fn get_color_background(s: &str) -> Option<Color> {
-    let s = s.trim_start();
-    let s = s.trim_end();
-    if s.contains("bright color") {
-      let s = s.trim_start_matches("bright ");
-      let c = s.trim_start_matches("color").parse::<u8>().unwrap_or_default();
-      Some(Color::Indexed(c.wrapping_shl(8)))
-    } else if s.contains("color") {
-      let c = s.trim_start_matches("color").parse::<u8>().unwrap_or_default();
-      Some(Color::Indexed(c))
-    } else if s.contains("gray") {
-      let s = s.trim_start_matches("bright ");
-      let c = 232 + s.trim_start_matches("gray").parse::<u8>().unwrap_or_default();
-      Some(Color::Indexed(c.wrapping_shl(8)))
-    } else if s.contains("rgb") {
-      let s = s.trim_start_matches("bright ");
-      let red = (s.as_bytes()[3] as char).to_digit(10).unwrap_or_default() as u8;
-      let green = (s.as_bytes()[4] as char).to_digit(10).unwrap_or_default() as u8;
-      let blue = (s.as_bytes()[5] as char).to_digit(10).unwrap_or_default() as u8;
-      let c = 16 + red * 36 + green * 6 + blue;
-      Some(Color::Indexed(c.wrapping_shl(8)))
-    } else if s == "bright black" {
-      Some(Color::Indexed(8))
-    } else if s == "bright red" {
-      Some(Color::Indexed(9))
-    } else if s == "bright green" {
-      Some(Color::Indexed(10))
-    } else if s == "bright yellow" {
-      Some(Color::Indexed(11))
-    } else if s == "bright blue" {
-      Some(Color::Indexed(12))
-    } else if s == "bright magenta" {
-      Some(Color::Indexed(13))
-    } else if s == "bright cyan" {
-      Some(Color::Indexed(14))
-    } else if s == "bright white" {
-      Some(Color::Indexed(15))
-    } else if s == "black" {
-      Some(Color::Indexed(0))
-    } else if s == "red" {
-      Some(Color::Indexed(1))
-    } else if s == "green" {
-      Some(Color::Indexed(2))
-    } else if s == "yellow" {
-      Some(Color::Indexed(3))
-    } else if s == "blue" {
-      Some(Color::Indexed(4))
-    } else if s == "magenta" {
-      Some(Color::Indexed(5))
-    } else if s == "cyan" {
-      Some(Color::Indexed(6))
-    } else if s == "white" {
-      Some(Color::Indexed(7))
-    } else {
-      None
+  /// Parse a background color. Handles the "bright" prefix for named colors
+  /// (e.g. "bright red" -> high-intensity red, index 8-15).
+  /// For indexed/gray/rgb colors the bright prefix is ignored (no bright variant exists).
+  fn parse_color_bg(s: &str, is_bright: bool) -> Option<Color> {
+    // For named colors with bright prefix, map to high-intensity variant (8-15)
+    if is_bright {
+      if let Some(idx) = Self::named_color_index(s) {
+        return Some(Color::Indexed(idx + 8));
+      }
+      // For colorN/gray/rgb with "bright" prefix, fall through to normal parsing
+      // (no bright variant for indexed colors — just use the index as-is)
+    }
+    Self::parse_color(s)
+  }
+
+  /// Map a plain color name to its 0-7 terminal index.
+  fn named_color_index(s: &str) -> Option<u8> {
+    match s.trim() {
+      "black" => Some(0),
+      "red" => Some(1),
+      "green" => Some(2),
+      "yellow" => Some(3),
+      "blue" => Some(4),
+      "magenta" => Some(5),
+      "cyan" => Some(6),
+      "white" => Some(7),
+      _ => None,
     }
   }
 
@@ -747,53 +761,17 @@ mod tests {
 
   #[test]
   fn test_colors() {
-    let c = Config::get_tcolor("red on blue");
+    // --- Basic named colors ---
+    let c = Config::get_tcolor("red");
     assert_eq!(c.fg.unwrap(), Color::Indexed(1));
-    assert_eq!(c.bg.unwrap(), Color::Indexed(4));
-
-    let c = Config::get_tcolor("bold red");
-    assert_eq!(c.fg.unwrap(), Color::Indexed(9));
     assert!(c.bg.is_none());
-    assert_eq!(c.add_modifier & Modifier::BOLD, Modifier::BOLD);
-
-    let c = Config::get_tcolor("white on red");
-    assert_eq!(c.fg.unwrap(), Color::Indexed(7));
-    assert_eq!(c.bg.unwrap(), Color::Indexed(1));
 
     let c = Config::get_tcolor("blue");
     assert_eq!(c.fg.unwrap(), Color::Indexed(4));
     assert!(c.bg.is_none());
 
-    let c = Config::get_tcolor("black on bright green");
-    assert_eq!(c.fg.unwrap(), Color::Indexed(0));
-    assert_eq!(c.bg.unwrap(), Color::Indexed(10));
-
-    let c = Config::get_tcolor("magenta");
-    assert_eq!(c.fg.unwrap(), Color::Indexed(5));
-    assert!(c.bg.is_none());
-
-    let c = Config::get_tcolor("white on green");
-    assert_eq!(c.fg.unwrap(), Color::Indexed(7));
-    assert_eq!(c.bg.unwrap(), Color::Indexed(2));
-
-    let c = Config::get_tcolor("black on white");
-    assert_eq!(c.fg.unwrap(), Color::Indexed(0));
-    assert_eq!(c.bg.unwrap(), Color::Indexed(7));
-
-    let c = Config::get_tcolor("black on bright white");
-    assert_eq!(c.fg.unwrap(), Color::Indexed(0));
-    assert_eq!(c.bg.unwrap(), Color::Indexed(15));
-
-    let c = Config::get_tcolor("bold white");
-    assert_eq!(c.fg.unwrap(), Color::Indexed(15));
-    assert!(c.bg.is_none());
-
     let c = Config::get_tcolor("white");
     assert_eq!(c.fg.unwrap(), Color::Indexed(7));
-    assert!(c.bg.is_none());
-
-    let c = Config::get_tcolor("bold yellow");
-    assert_eq!(c.fg.unwrap(), Color::Indexed(11));
     assert!(c.bg.is_none());
 
     let c = Config::get_tcolor("green");
@@ -804,25 +782,34 @@ mod tests {
     assert_eq!(c.fg.unwrap(), Color::Indexed(3));
     assert!(c.bg.is_none());
 
-    let c = Config::get_tcolor("red");
+    let c = Config::get_tcolor("magenta");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(5));
+    assert!(c.bg.is_none());
+
+    let c = Config::get_tcolor("cyan");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(6));
+    assert!(c.bg.is_none());
+
+    let c = Config::get_tcolor("black");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(0));
+    assert!(c.bg.is_none());
+
+    // --- Foreground + background (named) ---
+    let c = Config::get_tcolor("red on blue");
     assert_eq!(c.fg.unwrap(), Color::Indexed(1));
-    assert!(c.bg.is_none());
+    assert_eq!(c.bg.unwrap(), Color::Indexed(4));
 
-    let c = Config::get_tcolor("bold red");
-    assert_eq!(c.fg.unwrap(), Color::Indexed(9));
-    assert!(c.bg.is_none());
-
-    let c = Config::get_tcolor("on green");
-    assert!(c.fg.is_none());
-    assert_eq!(c.bg.unwrap(), Color::Indexed(2));
-
-    let c = Config::get_tcolor("on red");
-    assert!(c.fg.is_none());
+    let c = Config::get_tcolor("white on red");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(7));
     assert_eq!(c.bg.unwrap(), Color::Indexed(1));
 
-    let c = Config::get_tcolor("on yellow");
-    assert!(c.fg.is_none());
-    assert_eq!(c.bg.unwrap(), Color::Indexed(3));
+    let c = Config::get_tcolor("white on green");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(7));
+    assert_eq!(c.bg.unwrap(), Color::Indexed(2));
+
+    let c = Config::get_tcolor("black on white");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(0));
+    assert_eq!(c.bg.unwrap(), Color::Indexed(7));
 
     let c = Config::get_tcolor("black on red");
     assert_eq!(c.fg.unwrap(), Color::Indexed(0));
@@ -840,17 +827,27 @@ mod tests {
     assert_eq!(c.fg.unwrap(), Color::Indexed(7));
     assert_eq!(c.bg.unwrap(), Color::Indexed(0));
 
-    let c = Config::get_tcolor("black on green");
-    assert_eq!(c.fg.unwrap(), Color::Indexed(0));
+    // --- Background-only ---
+    let c = Config::get_tcolor("on green");
+    assert!(c.fg.is_none());
     assert_eq!(c.bg.unwrap(), Color::Indexed(2));
 
-    let c = Config::get_tcolor("white on red");
-    assert_eq!(c.fg.unwrap(), Color::Indexed(7));
+    let c = Config::get_tcolor("on red");
+    assert!(c.fg.is_none());
     assert_eq!(c.bg.unwrap(), Color::Indexed(1));
 
-    let c = Config::get_tcolor("bold white on red");
-    assert_eq!(c.fg.unwrap(), Color::Indexed(15));
-    assert_eq!(c.bg.unwrap(), Color::Indexed(1));
+    let c = Config::get_tcolor("on yellow");
+    assert!(c.fg.is_none());
+    assert_eq!(c.bg.unwrap(), Color::Indexed(3));
+
+    // --- bright backgrounds (high-intensity, indices 8-15) ---
+    let c = Config::get_tcolor("black on bright green");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(0));
+    assert_eq!(c.bg.unwrap(), Color::Indexed(10));
+
+    let c = Config::get_tcolor("black on bright white");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(0));
+    assert_eq!(c.bg.unwrap(), Color::Indexed(15));
 
     let c = Config::get_tcolor("black on bright yellow");
     assert_eq!(c.fg.unwrap(), Color::Indexed(0));
@@ -860,17 +857,159 @@ mod tests {
     assert_eq!(c.fg.unwrap(), Color::Indexed(0));
     assert_eq!(c.bg.unwrap(), Color::Indexed(9));
 
-    let c = Config::get_tcolor("bold white on bright blue");
-    assert_eq!(c.fg.unwrap(), Color::Indexed(15));
-    assert_eq!(c.bg.unwrap(), Color::Indexed(12));
-
     let c = Config::get_tcolor("white on bright black");
     assert_eq!(c.fg.unwrap(), Color::Indexed(7));
     assert_eq!(c.bg.unwrap(), Color::Indexed(8));
 
-    let c = Config::get_tcolor("bold blue");
-    assert_eq!(c.fg.unwrap(), Color::Indexed(12));
+    // --- bold modifier: sets BOLD, keeps regular color index (not high-intensity) ---
+    // This is the corrected behavior: "bold red" = regular red + BOLD attribute.
+    // Previously the buggy code mapped "bold red" to Indexed(9) (bright red).
+    let c = Config::get_tcolor("bold red");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(1));
     assert!(c.bg.is_none());
+    assert_eq!(c.add_modifier & Modifier::BOLD, Modifier::BOLD);
+
+    let c = Config::get_tcolor("bold white");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(7));
+    assert!(c.bg.is_none());
+    assert_eq!(c.add_modifier & Modifier::BOLD, Modifier::BOLD);
+
+    let c = Config::get_tcolor("bold yellow");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(3));
+    assert!(c.bg.is_none());
+    assert_eq!(c.add_modifier & Modifier::BOLD, Modifier::BOLD);
+
+    let c = Config::get_tcolor("bold blue");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(4));
+    assert!(c.bg.is_none());
+    assert_eq!(c.add_modifier & Modifier::BOLD, Modifier::BOLD);
+
+    let c = Config::get_tcolor("bold white on red");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(7));
+    assert_eq!(c.bg.unwrap(), Color::Indexed(1));
+    assert_eq!(c.add_modifier & Modifier::BOLD, Modifier::BOLD);
+
+    let c = Config::get_tcolor("bold white on bright blue");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(7));
+    assert_eq!(c.bg.unwrap(), Color::Indexed(12));
+    assert_eq!(c.add_modifier & Modifier::BOLD, Modifier::BOLD);
+
+    // --- underline modifier ---
+    let c = Config::get_tcolor("underline red");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(1));
+    assert_eq!(c.add_modifier & Modifier::UNDERLINED, Modifier::UNDERLINED);
+
+    let c = Config::get_tcolor("underline bold red on blue");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(1));
+    assert_eq!(c.bg.unwrap(), Color::Indexed(4));
+    assert_eq!(c.add_modifier & Modifier::UNDERLINED, Modifier::UNDERLINED);
+    assert_eq!(c.add_modifier & Modifier::BOLD, Modifier::BOLD);
+
+    // --- inverse modifier ---
+    let c = Config::get_tcolor("inverse red");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(1));
+    assert_eq!(c.add_modifier & Modifier::REVERSED, Modifier::REVERSED);
+
+    // --- italic modifier ---
+    let c = Config::get_tcolor("italic red");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(1));
+    assert_eq!(c.add_modifier & Modifier::ITALIC, Modifier::ITALIC);
+
+    let c = Config::get_tcolor("italic red on blue");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(1));
+    assert_eq!(c.bg.unwrap(), Color::Indexed(4));
+    assert_eq!(c.add_modifier & Modifier::ITALIC, Modifier::ITALIC);
+
+    // --- strikethrough modifier ---
+    let c = Config::get_tcolor("strikethrough red");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(1));
+    assert_eq!(c.add_modifier & Modifier::CROSSED_OUT, Modifier::CROSSED_OUT);
+
+    // --- combined modifiers ---
+    let c = Config::get_tcolor("bold underline italic red on blue");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(1));
+    assert_eq!(c.bg.unwrap(), Color::Indexed(4));
+    assert_eq!(c.add_modifier & Modifier::BOLD, Modifier::BOLD);
+    assert_eq!(c.add_modifier & Modifier::UNDERLINED, Modifier::UNDERLINED);
+    assert_eq!(c.add_modifier & Modifier::ITALIC, Modifier::ITALIC);
+
+    // --- 256-color indexed ---
+    let c = Config::get_tcolor("color0");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(0));
+
+    let c = Config::get_tcolor("color255");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(255));
+
+    let c = Config::get_tcolor("color100");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(100));
+
+    // colorN background (previously broken by wrapping_shl bug)
+    let c = Config::get_tcolor("white on color196");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(7));
+    assert_eq!(c.bg.unwrap(), Color::Indexed(196));
+
+    // --- grayscale ramp (gray0-gray23 -> indexed 232-255) ---
+    let c = Config::get_tcolor("gray0");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(232));
+
+    let c = Config::get_tcolor("gray23");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(255));
+
+    let c = Config::get_tcolor("gray5");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(237));
+
+    // grey spelling variant
+    let c = Config::get_tcolor("grey5");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(237));
+
+    // gray background (previously broken by wrapping_shl bug)
+    let c = Config::get_tcolor("white on gray5");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(7));
+    assert_eq!(c.bg.unwrap(), Color::Indexed(237));
+
+    let c = Config::get_tcolor("on gray23");
+    assert!(c.fg.is_none());
+    assert_eq!(c.bg.unwrap(), Color::Indexed(255));
+
+    // --- RGB color cube (rgb000-rgb555 -> indexed 16-231) ---
+    // rgb500 = 16 + 5*36 + 0*6 + 0 = 196
+    let c = Config::get_tcolor("rgb500");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(196));
+
+    // rgb050 = 16 + 0*36 + 5*6 + 0 = 46
+    let c = Config::get_tcolor("rgb050");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(46));
+
+    // rgb005 = 16 + 0 + 0 + 5 = 21
+    let c = Config::get_tcolor("rgb005");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(21));
+
+    // rgb550 = 16 + 5*36 + 5*6 + 0 = 226
+    let c = Config::get_tcolor("rgb550");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(226));
+
+    // rgb444 = 16 + 4*36 + 4*6 + 4 = 16 + 144 + 24 + 4 = 188
+    let c = Config::get_tcolor("rgb444");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(188));
+
+    // rgb background (previously broken by wrapping_shl bug)
+    let c = Config::get_tcolor("white on rgb500");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(7));
+    assert_eq!(c.bg.unwrap(), Color::Indexed(196));
+
+    let c = Config::get_tcolor("on rgb444");
+    assert!(c.fg.is_none());
+    assert_eq!(c.bg.unwrap(), Color::Indexed(188));
+
+    // --- TokyoNight Moon representative colors ---
+    // color111 on color60
+    let c = Config::get_tcolor("color111 on color60");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(111));
+    assert_eq!(c.bg.unwrap(), Color::Indexed(60));
+
+    // color203 (overdue/error red)
+    let c = Config::get_tcolor("color203");
+    assert_eq!(c.fg.unwrap(), Color::Indexed(203));
   }
 
   #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,7 @@
 use ratatui::{
   backend::Backend,
   layout::{Alignment, Constraint, Direction, Layout, Rect},
-  style::{Color, Modifier, Style},
+  style::Style,
   symbols,
   text::{Line, Span},
   widgets::{Block, BorderType, Borders, Cell, LineGauge, Paragraph, Row, Table},
@@ -17,18 +17,13 @@ pub fn draw(rect: &mut Frame, app: &TaskwarriorTui) {
     .constraints([Constraint::Length(3), Constraint::Min(10), Constraint::Length(3)].as_ref())
     .split(size);
 
-  let title = draw_title();
+  let title = draw_title(app.config.uda_style_title, app.config.uda_style_title_border);
   rect.render_widget(title, chunks[0]);
 }
 
-fn draw_title<'a>() -> Paragraph<'a> {
+fn draw_title<'a>(title_style: Style, border_style: Style) -> Paragraph<'a> {
   Paragraph::new("Taskwarrior TUI")
-    .style(Style::default().fg(Color::LightCyan))
+    .style(title_style)
     .alignment(Alignment::Center)
-    .block(
-      Block::default()
-        .borders(Borders::ALL)
-        .style(Style::default().fg(Color::White))
-        .border_type(BorderType::Plain),
-    )
+    .block(Block::default().borders(Borders::ALL).style(border_style).border_type(BorderType::Plain))
 }


### PR DESCRIPTION
currently, we have 2 gaps:
1. there are some hard-coded colors that cannot be configured
2. taskwarrior-tui parses colors differently from taskwarrior

This commit addresses both issues.
Please let me know if I should make changes, I am happy to do so! In the mean time, I am daily-driving my own build :)