### PR TITLE
fix: full redraw after opening external applications

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -381,7 +381,7 @@ impl TaskwarriorTui {
   pub async fn run(&mut self, terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
     loop {
       if self.requires_redraw {
-        terminal.autoresize()?;
+        terminal.clear()?;
         self.requires_redraw = false;
       }
       terminal.draw(|f| self.draw(f))?;


### PR DESCRIPTION
The `autoresize()` call didn't do anything because the external app got it's own terminal object, so ours never actually changed.

Before this fix, editing a task or running taskopen (as custom command) broke display, and only lines I moved to would be drawn.