### PR TITLE
chore: release v0.26.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.7](https://github.com/kdheepak/taskwarrior-tui/compare/v0.26.6...v0.26.7) - 2026-03-24
+
+### Fixed
+
+- perform full redraw after opening external applications ([#683](https://github.com/kdheepak/taskwarrior-tui/pull/683))
+
 ## [0.26.6](https://github.com/kdheepak/taskwarrior-tui/compare/v0.26.5...v0.26.6) - 2026-01-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "taskwarrior-tui"
-version = "0.26.6"
+version = "0.26.7"
 dependencies = [
  "anyhow",
  "better-panic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskwarrior-tui"
-version = "0.26.6"
+version = "0.26.7"
 license = "MIT"
 description = "A Taskwarrior Terminal User Interface"
 repository = "https://github.com/kdheepak/taskwarrior-tui/"


### PR DESCRIPTION



## 🤖 New release

* `taskwarrior-tui`: 0.26.6 -> 0.26.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.7](https://github.com/kdheepak/taskwarrior-tui/compare/v0.26.6...v0.26.7) - 2026-03-24

### Fixed

- perform full redraw after opening external applications ([#683](https://github.com/kdheepak/taskwarrior-tui/pull/683))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).