### PR TITLE
feat: implement alternating line colors a la taskwarrior

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ report.next.filter=(status:pending or status:waiting) page:limit
 
 uda.taskwarrior-tui.keyconfig.done=x
 uda.taskwarrior-tui.keyconfig.delete=d
+uda.taskwarrior-tui.task-report.use-alternate-style=false
 uda.taskwarrior-tui.shortcuts.1=~/local/bin/task-sync.sh
 uda.taskwarrior-tui.report.next.filter=(status:pending or status:waiting)
 ```

--- a/docs/src/content/docs/configuration/advanced.md
+++ b/docs/src/content/docs/configuration/advanced.md
@@ -23,6 +23,7 @@ uda.taskwarrior-tui.unmark-selection.indicator=⦾
 uda.taskwarrior-tui.calendar.months-per-row=4
 uda.taskwarrior-tui.task-report.show-info=true
 uda.taskwarrior-tui.task-report.looping=true
+uda.taskwarrior-tui.task-report.use-alternate-style=true
 uda.taskwarrior-tui.task-report.jump-on-task-add=true
 uda.taskwarrior-tui.task-report.prompt-on-undo=false
 uda.taskwarrior-tui.task-report.prompt-on-delete=false
@@ -51,6 +52,8 @@ uda.taskwarrior-tui.style.command.error= # default: Red foreground
 ```
 
 The `uda.taskwarrior-tui.task-report.next.filter` variable defines the default view at program startup. Set this to any preconfigured report from `task reports`, or create your own report in Taskwarrior and specify its name here.
+
+Set `uda.taskwarrior-tui.task-report.use-alternate-style=false` to stop the TUI from applying `color.alternate` to every other task row while leaving Taskwarrior's own color settings unchanged.
 
 ## Command-Line Options
 

--- a/docs/src/content/docs/configuration/colors.md
+++ b/docs/src/content/docs/configuration/colors.md
@@ -17,6 +17,7 @@ The following color attributes are supported:
 color.deleted
 color.completed
 color.active
+color.alternate
 color.overdue
 color.scheduled
 color.due.today
@@ -26,6 +27,8 @@ color.blocking
 color.recurring
 color.tagged
 ```
+
+`color.alternate` is applied to every other row in the task report by default. If you want to keep that Taskwarrior color defined but disable it in the TUI, set `uda.taskwarrior-tui.task-report.use-alternate-style=false`.
 
 ## Color Formats
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1351,6 +1351,16 @@ impl TaskwarriorTui {
     style
   }
 
+  fn task_report_row_style(&self, row_index: usize, task: &Task) -> Style {
+    let base_style = if row_index % 2 == 1 && self.config.uda_task_report_use_alternate_style {
+      self.config.color.get("color.alternate").copied().unwrap_or_default()
+    } else {
+      Style::default()
+    };
+
+    base_style.patch(self.style_for_task(task))
+  }
+
   pub fn calculate_widths(&self, tasks: &[Vec<String>], headers: &[String], maximum_column_width: u16) -> Vec<usize> {
     // naive implementation of calculate widths
     let mut widths = headers.iter().map(String::len).collect::<Vec<usize>>();
@@ -1413,13 +1423,7 @@ impl TaskwarriorTui {
     let mut highlight_style = Style::default();
     let mut pos = 0;
     for (i, task) in tasks.iter().enumerate() {
-      // Apply alternating row color as base style for odd rows
-      let base_style = if i % 2 == 1 {
-        self.config.color.get("color.alternate").copied().unwrap_or_default()
-      } else {
-        Style::default()
-      };
-      let style = base_style.patch(self.style_for_task(&self.tasks[i]));
+      let style = self.task_report_row_style(i, &self.tasks[i]);
       if i == selected {
         pos = i;
         highlight_style = style.patch(self.config.uda_style_report_selection);
@@ -4442,6 +4446,7 @@ mod tests {
     // test_draw_task_report();
     test_task_tags().await;
     test_task_style().await;
+    test_task_report_alternate_style().await;
     test_task_context().await;
     test_task_tomorrow().await;
     test_task_earlier_today().await;
@@ -4532,6 +4537,29 @@ mod tests {
 
     let task = app.task_by_id(11).unwrap();
     let style = app.style_for_task(&task);
+  }
+
+  async fn test_task_report_alternate_style() {
+    let mut app = TaskwarriorTui::new("next", false).await.unwrap();
+    assert!(app.update(true).await.is_ok());
+
+    let alternate_style = Style::default()
+      .fg(Color::Indexed(5))
+      .bg(Color::Indexed(2))
+      .add_modifier(Modifier::ITALIC);
+    app.config.color.insert("color.alternate".to_string(), alternate_style);
+    let task = app.task_by_id(1).unwrap();
+
+    let default_style = app.task_report_row_style(0, &task);
+    let odd_row_style = app.task_report_row_style(1, &task);
+
+    assert_eq!(default_style, Style::default());
+    assert_eq!(odd_row_style, alternate_style);
+
+    app.config.uda_task_report_use_alternate_style = false;
+    let disabled_style = app.task_report_row_style(1, &task);
+
+    assert_eq!(disabled_style, Style::default());
   }
 
   async fn test_task_context() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,7 @@ pub struct Config {
   pub uda_reset_filter_on_esc: bool,
   pub uda_task_detail_prefetch: usize,
   pub uda_task_report_use_all_tasks_for_completion: bool,
+  pub uda_task_report_use_alternate_style: bool,
   pub uda_task_report_show_info: bool,
   pub uda_task_report_looping: bool,
   pub uda_task_report_jump_to_task_on_add: bool,
@@ -139,6 +140,7 @@ impl Config {
     let uda_reset_filter_on_esc = Self::get_uda_reset_filter_on_esc(data);
     let uda_task_detail_prefetch = Self::get_uda_task_detail_prefetch(data);
     let uda_task_report_use_all_tasks_for_completion = Self::get_uda_task_report_use_all_tasks_for_completion(data);
+    let uda_task_report_use_alternate_style = Self::get_uda_task_report_use_alternate_style(data);
     let uda_task_report_show_info = Self::get_uda_task_report_show_info(data);
     let uda_task_report_looping = Self::get_uda_task_report_looping(data);
     let uda_task_report_jump_to_task_on_add = Self::get_uda_task_report_jump_to_task_on_add(data);
@@ -218,6 +220,7 @@ impl Config {
       uda_reset_filter_on_esc,
       uda_task_detail_prefetch,
       uda_task_report_use_all_tasks_for_completion,
+      uda_task_report_use_alternate_style,
       uda_task_report_show_info,
       uda_task_report_looping,
       uda_task_report_jump_to_task_on_add,
@@ -583,6 +586,13 @@ impl Config {
       .unwrap_or_default()
       .get_bool()
       .unwrap_or(false)
+  }
+
+  fn get_uda_task_report_use_alternate_style(data: &str) -> bool {
+    Self::get_config("uda.taskwarrior-tui.task-report.use-alternate-style", data)
+      .unwrap_or_default()
+      .get_bool()
+      .unwrap_or(true)
   }
 
   fn get_uda_task_report_show_info(data: &str) -> bool {
@@ -1049,5 +1059,16 @@ mod tests {
       "report.test.description test\nreport.test.filter filter and\n                   test",
     );
     assert_eq!(config.unwrap(), "filter and test");
+  }
+
+  #[test]
+  fn test_get_uda_task_report_use_alternate_style_defaults_to_true() {
+    assert!(Config::get_uda_task_report_use_alternate_style(""));
+  }
+
+  #[test]
+  fn test_get_uda_task_report_use_alternate_style_can_be_disabled() {
+    let data = "uda.taskwarrior-tui.task-report.use-alternate-style false";
+    assert!(!Config::get_uda_task_report_use_alternate_style(data));
   }
 }


### PR DESCRIPTION
This tweak applies `color.alternate` on alternating lines like `taskwarrior` does.

I do wonder if there was a reason this was not implemented previously. Should this be separately configurable from taskwarrior? I figure if users want to configure it they can, however it will apply to both the TUI and regular.