### PR TITLE
chore: release v0.26.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.11](https://github.com/kdheepak/taskwarrior-tui/compare/v0.26.10...v0.26.11) - 2026-04-08
+
+### Added
+
+- add "timesheet" tab ([#728](https://github.com/kdheepak/taskwarrior-tui/pull/728))
+
+### Other
+
+- *(deps)* narrow `tokio`'s featureset; remove unused `tokio-stream` ([#731](https://github.com/kdheepak/taskwarrior-tui/pull/731))
+- *(deps)* `cassowary` -> `kasuari` ([#734](https://github.com/kdheepak/taskwarrior-tui/pull/734))
+- *(deps)* remove unused features; remove unused deps ([#732](https://github.com/kdheepak/taskwarrior-tui/pull/732))
+
 ## [0.26.10](https://github.com/kdheepak/taskwarrior-tui/compare/v0.26.9...v0.26.10) - 2026-04-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "taskwarrior-tui"
-version = "0.26.10"
+version = "0.26.11"
 dependencies = [
  "anyhow",
  "better-panic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskwarrior-tui"
-version = "0.26.10"
+version = "0.26.11"
 license = "MIT"
 description = "A Taskwarrior Terminal User Interface"
 repository = "https://github.com/kdheepak/taskwarrior-tui/"


### PR DESCRIPTION



## 🤖 New release

* `taskwarrior-tui`: 0.26.10 -> 0.26.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.11](https://github.com/kdheepak/taskwarrior-tui/compare/v0.26.10...v0.26.11) - 2026-04-08

### Added

- add "timesheet" tab ([#728](https://github.com/kdheepak/taskwarrior-tui/pull/728))

### Other

- *(deps)* narrow `tokio`'s featureset; remove unused `tokio-stream` ([#731](https://github.com/kdheepak/taskwarrior-tui/pull/731))
- *(deps)* `cassowary` -> `kasuari` ([#734](https://github.com/kdheepak/taskwarrior-tui/pull/734))
- *(deps)* remove unused features; remove unused deps ([#732](https://github.com/kdheepak/taskwarrior-tui/pull/732))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).