### PR TITLE
chore: release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0](https://github.com/kdheepak/taskwarrior-tui/compare/v0.26.12...v0.27.0) - 2026-04-09
+
+### Added
+
+- [**breaking**] auto functionality for task info show ([#743](https://github.com/kdheepak/taskwarrior-tui/pull/743))
+
+### Other
+
+- Add information about quick-tag to documentation ([#746](https://github.com/kdheepak/taskwarrior-tui/pull/746))
+- Update README.md ([#745](https://github.com/kdheepak/taskwarrior-tui/pull/745))
+- Add demo vhs tape ([#742](https://github.com/kdheepak/taskwarrior-tui/pull/742))
+
 ## [0.26.12](https://github.com/kdheepak/taskwarrior-tui/compare/v0.26.11...v0.26.12) - 2026-04-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "taskwarrior-tui"
-version = "0.26.12"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "better-panic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskwarrior-tui"
-version = "0.26.12"
+version = "0.27.0"
 license = "MIT"
 description = "A Taskwarrior Terminal User Interface"
 repository = "https://github.com/kdheepak/taskwarrior-tui/"


### PR DESCRIPTION



## 🤖 New release

* `taskwarrior-tui`: 0.26.12 -> 0.27.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.27.0](https://github.com/kdheepak/taskwarrior-tui/compare/v0.26.12...v0.27.0) - 2026-04-09

### Added

- [**breaking**] auto functionality for task info show ([#743](https://github.com/kdheepak/taskwarrior-tui/pull/743))

### Other

- Add information about quick-tag to documentation ([#746](https://github.com/kdheepak/taskwarrior-tui/pull/746))
- Update README.md ([#745](https://github.com/kdheepak/taskwarrior-tui/pull/745))
- Add demo vhs tape ([#742](https://github.com/kdheepak/taskwarrior-tui/pull/742))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).