### PR TITLE
fix: Subprojects not being colored

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1499,8 +1499,13 @@ impl TaskwarriorTui {
         }
       } else if tag_name == "project." {
         if let Some(p) = task.project() {
-          let s = self.config.color.get(&format!("color.project.{}", p)).copied().unwrap_or_default();
-          style = style.patch(s);
+          for (key, s) in &self.config.color {
+            if let Some(rule_project) = key.strip_prefix("color.project.") {
+              if p.starts_with(rule_project) {
+                style = style.patch(*s);
+              }
+            }
+          }
         }
       } else if tag_name == "keyword." {
         let desc = task.description();


### PR DESCRIPTION
Fixes #768

---
**DISCLAIMER: I did use AI to analyze existing tui and taskwarrior codebases to compare both behaviours.**
---

In spirit of _this mr_ I tried to replicate original taskwarrior behaviour which is [left-most match](https://github.com/GothenburgBitFactory/taskwarrior/blob/develop/src/rules.cpp#L127-L140).

Test data that I used to verify can be found here: https://github.com/rtim75/taskwarrior-testdata

This makes tui to check if task's project starts with the project specified in the rule.K

Resulting behaviour can be seen on the screenshot below:
<img width="2880" height="1804" alt="image" src="https://github.com/user-attachments/assets/4034e6c4-7600-4bde-94c6-385063cd577e" />

