### PR TITLE
feat: nested tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ uda.taskwarrior-tui.report.next.filter=(status:pending or status:waiting)
 
 </details>
 
+<details>
+<summary>Enabling nested tasks (experimental)</summary>
+
+```.sh
+task config uda.taskwarrior-tui.nested true 
+```
+
+</details>
+
 ### References / Resources
 
 If you like `taskwarrior-tui`, please consider donating to

--- a/src/app.rs
+++ b/src/app.rs
@@ -154,6 +154,9 @@ pub struct TaskwarriorTui {
   pub current_selection_uuid: Option<Uuid>,
   pub current_selection_id: Option<u64>,
   pub task_report_table: TaskReportTable,
+  pub nested: bool,
+  pub focus_stack: Vec<(String, String)>,
+  pub subtask_parent: Option<String>,
   pub calendar_year: i32,
   pub mode: Mode,
   pub previous_mode: Option<Mode>,
@@ -256,6 +259,9 @@ impl TaskwarriorTui {
       task_details_scroll: 0,
       task_details_defaultwidth: 0,
       task_report_info_show: c.uda_task_report_info_show,
+      nested: c.uda_nested,
+      focus_stack: vec![],
+      subtask_parent: None,
       task_info_location_override: None,
       task_info_location_override_width: None,
       config: c,
@@ -503,17 +509,28 @@ impl TaskwarriorTui {
       Mode::Calendar => 3,
     };
     let navbar_block = Block::default().style(self.config.uda_style_navbar);
-    let context = Line::from(vec![
-      Span::from(&self.report),
-      Span::from(" "),
-      Span::from("["),
-      Span::from(if self.current_context.is_empty() {
-        "none"
-      } else {
-        &self.current_context
-      }),
-      Span::from("]"),
-    ]);
+    let context = Line::from(
+      vec![
+        Span::from(&self.report),
+        Span::from(" "),
+        Span::from("["),
+        Span::from(if self.current_context.is_empty() {
+          "none"
+        } else {
+          &self.current_context
+        }),
+        Span::from("]"),
+      ]
+      .into_iter()
+      .chain(
+        self
+          .focus_stack
+          .iter()
+          .filter(|_| matches!(self.mode, Mode::Tasks(_)))
+          .flat_map(|(_, d)| [Span::from(" \u{203a} "), Span::from(d.as_str())]),
+      )
+      .collect::<Vec<_>>(),
+    );
     let tabs = Tabs::new(tab_names)
       .block(navbar_block.clone())
       .select(selected_tab)
@@ -971,7 +988,14 @@ impl TaskwarriorTui {
           rects[1],
           self.command.as_str(),
           (
-            Span::styled("Add Task", Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled(
+              match &self.subtask_parent {
+                None => "Add Task",
+                Some(p) if self.focus_stack.last().map(|(u, _)| u) == Some(p) => "Add Sub-Task Here",
+                Some(_) => "Add Sub-Task",
+              },
+              Style::default().add_modifier(Modifier::BOLD),
+            ),
             self
               .history_status
               .as_ref()
@@ -1675,6 +1699,7 @@ impl TaskwarriorTui {
       if self.config.uda_task_report_use_all_tasks_for_completion {
         self.export_all_tasks()?;
       }
+      self.update_child_counts();
       self.contexts.update_data(&self.task_exe)?;
       self.reports.update_data(&self.report, &Self::task_show_output(&self.task_exe)?);
       self.projects.update_data(&self.task_exe)?;
@@ -1877,6 +1902,7 @@ impl TaskwarriorTui {
     let mut command = std::process::Command::new(&self.task_exe);
     command.arg("context").arg(context);
     command.output()?;
+    self.focus_stack.clear();
     Ok(true)
   }
 
@@ -1974,6 +2000,7 @@ impl TaskwarriorTui {
     }
 
     self.task_report_table.export_headers(Some(data), &self.report, &self.task_exe)?;
+    self.focus_stack.clear();
     Ok(true)
   }
 
@@ -2208,6 +2235,31 @@ impl TaskwarriorTui {
     Ok(())
   }
 
+  fn focus_filter(&self) -> Option<String> {
+    if !self.nested {
+      return None;
+    }
+    Some(match self.focus_stack.last() {
+      Some((uuid, _)) => format!("partof:{}", uuid),
+      None => "partof.none:".to_string(),
+    })
+  }
+
+  fn report_filter(&self, extra: Option<&str>) -> String {
+    let base = self.filter.as_str().trim();
+    if !self.nested {
+      return base.to_string();
+    }
+    let mut parts: Vec<&str> = base
+      .split_whitespace()
+      .filter(|w| !w.starts_with("partof:") && !w.starts_with("partof."))
+      .collect();
+    if let Some(term) = extra {
+      parts.push(term);
+    }
+    parts.join(" ")
+  }
+
   pub fn export_tasks(&mut self) -> Result<()> {
     let mut task = std::process::Command::new(&self.task_exe);
 
@@ -2219,7 +2271,8 @@ impl TaskwarriorTui {
       .arg("rc._forcecolor=off");
     // .arg("rc.verbose:override=false");
 
-    if let Some(args) = shlex::split(format!(r#"rc.report.{}.filter='{}'"#, self.report, self.filter.trim()).trim()) {
+    let report_filter = self.report_filter(self.focus_filter().as_deref());
+    if let Some(args) = shlex::split(format!(r#"rc.report.{}.filter='{}'"#, self.report, report_filter).trim()) {
       for arg in args {
         task.arg(arg);
       }
@@ -2269,6 +2322,100 @@ impl TaskwarriorTui {
       self.error = Some(format!("Cannot run `{:?}` - ({}) error:\n{}", &task, output.status, error));
     }
 
+    Ok(())
+  }
+
+  fn update_child_counts(&mut self) {
+    if !self.nested {
+      self.task_report_table.child_counts.clear();
+      return;
+    }
+
+    let mut task = std::process::Command::new(&self.task_exe);
+
+    task
+      .arg("rc.json.array=on")
+      .arg("rc.confirmation=off")
+      .arg("rc.json.depends.array=on")
+      .arg("rc.color=off")
+      .arg("rc._forcecolor=off");
+
+    let report_filter = self.report_filter(Some("partof.any:"));
+    if let Some(args) = shlex::split(format!(r#"rc.report.{}.filter='{}'"#, self.report, report_filter).trim()) {
+      for arg in args {
+        task.arg(arg);
+      }
+    }
+
+    if !self.current_context_filter.trim().is_empty() && self.task_version >= *TASKWARRIOR_VERSION_SUPPORTED {
+      if let Some(args) = shlex::split(&self.current_context_filter) {
+        for arg in args {
+          task.arg(arg);
+        }
+      }
+    } else if !self.current_context_filter.trim().is_empty() {
+      task.arg(format!("'\\({}\\)'", self.current_context_filter));
+    }
+
+    task.arg("export");
+
+    if self.task_version >= *TASKWARRIOR_VERSION_SUPPORTED {
+      task.arg(&self.report);
+    }
+
+    let mut counts: HashMap<Uuid, usize> = HashMap::new();
+    match task.output() {
+      Ok(output) if output.status.success() => {
+        let data = String::from_utf8_lossy(&output.stdout);
+        let tasks: Vec<Task> = import(data.as_bytes()).unwrap_or_default();
+        for t in &tasks {
+          if let Some(UDAValue::Str(p)) = t.uda().get("partof")
+            && let Ok(uuid) = Uuid::parse_str(p)
+          {
+            *counts.entry(uuid).or_default() += 1;
+          }
+        }
+      }
+      Ok(output) => debug!("Unable to compute child counts: {}", String::from_utf8_lossy(&output.stderr)),
+      Err(e) => debug!("Unable to run child-count export: {}", e),
+    }
+    self.task_report_table.child_counts = counts;
+  }
+
+  fn begin_task_add(&mut self, subtask_parent: Option<String>) {
+    self.subtask_parent = subtask_parent;
+    self.mode = Mode::Tasks(Action::Add);
+    self.command_history.reset();
+    self.history_status = Some(format!(
+      "{} / {}",
+      self
+        .command_history
+        .history_index()
+        .unwrap_or_else(|| self.command_history.history_len().saturating_sub(1))
+        .saturating_add(1),
+      self.command_history.history_len()
+    ));
+    self.update_completion_list();
+  }
+
+  async fn traverse_down(&mut self) -> Result<()> {
+    let Some(task) = self.task_current() else {
+      return Ok(());
+    };
+    self.focus_stack.push((task.uuid().to_string(), task.description().to_string()));
+    self.update(true).await?;
+    self.current_selection = 0;
+    self.current_selection_uuid = None;
+    self.current_selection_id = None;
+    self.update_task_table_state();
+    Ok(())
+  }
+
+  async fn traverse_up(&mut self) -> Result<()> {
+    if let Some((uuid, _)) = self.focus_stack.pop() {
+      self.current_selection_uuid = Uuid::parse_str(&uuid).ok();
+      self.update(true).await?;
+    }
     Ok(())
   }
 
@@ -2551,6 +2698,10 @@ impl TaskwarriorTui {
   pub fn task_add(&mut self) -> Result<(), String> {
     let mut command = std::process::Command::new(&self.task_exe);
     command.arg("add");
+
+    if let Some(uuid) = self.subtask_parent.take() {
+      command.arg(format!("partof:{}", uuid));
+    }
 
     let shell = self.command.as_str();
 
@@ -3117,8 +3268,22 @@ impl TaskwarriorTui {
     if let Mode::Tasks(task_mode) = &self.mode {
       match task_mode {
         Action::Report => {
-          if input == KeyCode::Esc {
+          if self.nested && !self.focus_stack.is_empty() && (input == KeyCode::Esc || input == self.keyconfig.traverse_up) {
+            self.traverse_up().await?;
+          } else if input == KeyCode::Esc {
             self.marked.clear();
+          } else if self.nested && input == self.keyconfig.traverse_down {
+            self.traverse_down().await?;
+          } else if self.nested && input == self.keyconfig.subtask {
+            let parent = self
+              .task_current()
+              .map(|t| t.uuid().to_string())
+              .or_else(|| self.focus_stack.last().map(|(u, _)| u.clone()));
+            self.begin_task_add(parent);
+          } else if self.nested && input == self.keyconfig.subtask_sibling {
+            if let Some(uuid) = self.focus_stack.last().map(|(u, _)| u.clone()) {
+              self.begin_task_add(Some(uuid));
+            }
           } else if input == self.keyconfig.quit || input == KeyCode::Ctrl('c') {
             self.should_quit = true;
           } else if input == self.keyconfig.select {
@@ -3992,6 +4157,7 @@ impl TaskwarriorTui {
             } else {
               self.reset_command();
               self.history_status = None;
+              self.subtask_parent = None;
               self.mode = Mode::Tasks(Action::Report);
             }
           }

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,6 +101,7 @@ pub struct Config {
   pub uda_task_report_info_show: bool,
   pub uda_task_report_looping: bool,
   pub uda_task_report_jump_to_task_on_add: bool,
+  pub uda_nested: bool,
   pub uda_selection_indicator: String,
   pub uda_mark_highlight_indicator: String,
   pub uda_unmark_highlight_indicator: String,
@@ -183,6 +184,7 @@ impl Config {
     let uda_task_report_info_show = Self::get_uda_task_report_info_show(data);
     let uda_task_report_looping = Self::get_uda_task_report_looping(data);
     let uda_task_report_jump_to_task_on_add = Self::get_uda_task_report_jump_to_task_on_add(data);
+    let uda_nested = Self::get_uda_nested(data);
     let uda_selection_indicator = Self::get_uda_selection_indicator(data);
     let uda_mark_highlight_indicator = Self::get_uda_mark_highlight_indicator(data);
     let uda_unmark_highlight_indicator = Self::get_uda_unmark_highlight_indicator(data);
@@ -266,6 +268,7 @@ impl Config {
       uda_task_report_info_show,
       uda_task_report_looping,
       uda_task_report_jump_to_task_on_add,
+      uda_nested,
       uda_selection_indicator,
       uda_mark_highlight_indicator,
       uda_unmark_highlight_indicator,
@@ -696,6 +699,13 @@ impl Config {
       .unwrap_or_default()
       .get_bool()
       .unwrap_or(true)
+  }
+
+  fn get_uda_nested(data: &str) -> bool {
+    Self::get_config("uda.taskwarrior-tui.nested", data)
+      .unwrap_or_default()
+      .get_bool()
+      .unwrap_or(false)
   }
 
   fn get_uda_task_report_looping(data: &str) -> bool {

--- a/src/help.rs
+++ b/src/help.rs
@@ -47,6 +47,8 @@ fn keycode_for(name: &str, kc: &KeyConfig) -> KeyCode {
     "delete" => kc.delete,
     "zoom" => kc.zoom,
     "annotate" => kc.annotate,
+    "subtask" => kc.subtask,
+    "subtask_sibling" => kc.subtask_sibling,
     "shell" => kc.shell,
     "shortcut0" => kc.shortcut0,
     "shortcut1" => kc.shortcut1,

--- a/src/help.tmpl
+++ b/src/help.tmpl
@@ -4,6 +4,8 @@ Keybindings:
 
     Esc:                                 - Exit current action
 
+    Enter:                               - Expand selected task (nested mode)
+
     {{next_tab}}: Next view                         - Go to next view
 
     {{previous_tab}}: Previous view                     - Go to previous view
@@ -53,6 +55,10 @@ Keybindings for task report:
     {{zoom}}: toggle task info                  - Toggle task info view
 
     {{annotate}}: task {selected} annotate {string} - Annotate current task
+
+    {{subtask}}: add sub-task                      - Add sub-task for highlighted task (nested mode)
+
+    {{subtask_sibling}}: add sub-task here             - Add sub-task at the current level (nested mode)
 
     Ctrl-e: scroll down task details     - Scroll task details view down one line
 

--- a/src/keyconfig.rs
+++ b/src/keyconfig.rs
@@ -38,6 +38,10 @@ pub struct KeyConfig {
   pub report_menu: KeyCode,
   pub next_tab: KeyCode,
   pub previous_tab: KeyCode,
+  pub traverse_down: KeyCode,
+  pub traverse_up: KeyCode,
+  pub subtask: KeyCode,
+  pub subtask_sibling: KeyCode,
   pub priority_h: KeyCode,
   pub priority_m: KeyCode,
   pub priority_l: KeyCode,
@@ -87,6 +91,10 @@ impl Default for KeyConfig {
       report_menu: KeyCode::Char('R'),
       next_tab: KeyCode::Char(']'),
       previous_tab: KeyCode::Char('['),
+      traverse_down: KeyCode::Char('\n'),
+      traverse_up: KeyCode::Esc,
+      subtask: KeyCode::Char('w'),
+      subtask_sibling: KeyCode::Char('W'),
       priority_h: KeyCode::Char('H'),
       priority_m: KeyCode::Char('M'),
       priority_l: KeyCode::Char('L'),
@@ -142,6 +150,10 @@ impl KeyConfig {
     let report_menu = Self::get_config("uda.taskwarrior-tui.keyconfig.report-menu", data);
     let next_tab = Self::get_config("uda.taskwarrior-tui.keyconfig.next-tab", data);
     let previous_tab = Self::get_config("uda.taskwarrior-tui.keyconfig.previous-tab", data);
+    let traverse_down = Self::get_config("uda.taskwarrior-tui.keyconfig.traverse-down", data);
+    let traverse_up = Self::get_config("uda.taskwarrior-tui.keyconfig.traverse-up", data);
+    let subtask = Self::get_config("uda.taskwarrior-tui.keyconfig.subtask", data);
+    let subtask_sibling = Self::get_config("uda.taskwarrior-tui.keyconfig.subtask-sibling", data);
     let shortcut0 = Self::get_config("uda.taskwarrior-tui.keyconfig.shortcut0", data);
     let shortcut1 = Self::get_config("uda.taskwarrior-tui.keyconfig.shortcut1", data);
     let shortcut2 = Self::get_config("uda.taskwarrior-tui.keyconfig.shortcut2", data);
@@ -182,6 +194,10 @@ impl KeyConfig {
     self.report_menu = report_menu.unwrap_or(self.report_menu);
     self.next_tab = next_tab.unwrap_or(self.next_tab);
     self.previous_tab = previous_tab.unwrap_or(self.previous_tab);
+    self.traverse_down = traverse_down.unwrap_or(self.traverse_down);
+    self.traverse_up = traverse_up.unwrap_or(self.traverse_up);
+    self.subtask = subtask.unwrap_or(self.subtask);
+    self.subtask_sibling = subtask_sibling.unwrap_or(self.subtask_sibling);
     self.shortcut0 = shortcut0.unwrap_or(self.shortcut0);
     self.shortcut1 = shortcut1.unwrap_or(self.shortcut1);
     self.shortcut2 = shortcut2.unwrap_or(self.shortcut2);

--- a/src/task_report.rs
+++ b/src/task_report.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, process::Command};
+use std::{collections::HashMap, error::Error, process::Command};
 
 use anyhow::Result;
 use chrono::{Datelike, Local, NaiveDateTime};
@@ -6,6 +6,7 @@ use itertools::join;
 use task_hookrs::{task::Task, uda::UDAValue};
 use unicode_truncate::UnicodeTruncateStr;
 use unicode_width::UnicodeWidthStr;
+use uuid::Uuid;
 
 use crate::{datetime, utils};
 
@@ -117,6 +118,7 @@ pub struct TaskReportTable {
   pub description_width: usize,
   pub date_time_vague_precise: bool,
   pub date_format: String,
+  pub child_counts: HashMap<Uuid, usize>,
 }
 
 impl TaskReportTable {
@@ -165,6 +167,7 @@ impl TaskReportTable {
       description_width: 100,
       date_time_vague_precise: false,
       date_format: "%Y-%m-%d".to_string(),
+      child_counts: HashMap::new(),
     };
     task_report_table.export_headers(Some(data), report, task_exe)?;
     Ok(task_report_table)
@@ -262,6 +265,14 @@ impl TaskReportTable {
       let mut item = vec![];
       for name in &self.columns {
         let s = self.get_string_attribute(name, task, tasks);
+        let s = if name == "description" || name.starts_with("description.") {
+          match self.child_counts.get(task.uuid()).copied().unwrap_or(0) {
+            0 => s,
+            n => format!("\u{25b8}{} {}", n, s),
+          }
+        } else {
+          s
+        };
         item.push(s);
       }
       self.tasks.push(item);


### PR DESCRIPTION
Adds nested tasks and the ability to traverse through tasks in the TUI using Enter and Escape. Helps address #603 and I'm sure there are others besides myself who will appreciate this feature.

Sub-Tasks can be added downstream of a highlighted task using w, and to the current view using W. I wasn't 100% sure for the default keybindings here but I couldn't think of anything else. I'm open to feedback.

**NOTE:** Since this is a large, maybe experimental change I've gated it behind `task config uda.taskwarrior-tui.nested true`

## Demo

[![asciicast](https://asciinema.org/a/Uk9T5AgMSaajxc5R.svg)](https://asciinema.org/a/Uk9T5AgMSaajxc5R)

