### PR TITLE
feat(completion): complete recurrence values for recur: and add until:

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4318,8 +4318,36 @@ impl TaskwarriorTui {
         "depends:".to_string(),
         "tag:".to_string(),
         "recur:".to_string(),
+        "until:".to_string(),
       ] {
         self.completion_list.insert(("attribute".to_string(), s));
+      }
+      for s in [
+        "daily",
+        "weekdays",
+        "weekly",
+        "biweekly",
+        "fortnight",
+        "monthly",
+        "bimonthly",
+        "quarterly",
+        "semiannual",
+        "yearly",
+        "biyearly",
+        "2d",
+        "3d",
+        "2w",
+        "2m",
+        "3m",
+        "6m",
+        "2y",
+      ] {
+        self.completion_list.insert(("recur".to_string(), s.to_string()));
+      }
+      for task in tasks {
+        if let Some(r) = task.recur() {
+          self.completion_list.insert(("recur".to_string(), r.to_string()));
+        }
       }
     }
 


### PR DESCRIPTION
## What

`recur:` previously tab-completed as an attribute name but offered no values. This adds:

- static candidates for the common taskwarrior recurrence periods (`daily`, `weekdays`, `weekly`, `biweekly`, `fortnight`, `monthly`, `bimonthly`, `quarterly`, `semiannual`, `yearly`, `biyearly`, and short numeric forms like `2d`/`2w`/`3m`)
- dynamic candidates from recurrence values already used by existing tasks
- `until:` added to the completed attribute names, since it usually accompanies `recur:`

## Notes

Single-file change in `update_completion_list`. `cargo fmt` and `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)