### PR TITLE
feat: suppress selection follow if configured with `jump-to-task-on-modify`

### DIFF
--- a/docs/src/content/docs/configuration/advanced.md
+++ b/docs/src/content/docs/configuration/advanced.md
@@ -26,6 +26,7 @@ uda.taskwarrior-tui.task-report.info-location=auto
 uda.taskwarrior-tui.task-report.looping=true
 uda.taskwarrior-tui.task-report.use-alternate-style=true
 uda.taskwarrior-tui.task-report.jump-to-task-on-add=true
+uda.taskwarrior-tui.task-report.jump-to-task-on-modify=true
 uda.taskwarrior-tui.task-report.prompt-on-undo=false
 uda.taskwarrior-tui.task-report.prompt-on-delete=false
 uda.taskwarrior-tui.task-report.prompt-on-done=false

--- a/src/app.rs
+++ b/src/app.rs
@@ -153,6 +153,7 @@ pub struct TaskwarriorTui {
   pub current_selection: usize,
   pub current_selection_uuid: Option<Uuid>,
   pub current_selection_id: Option<u64>,
+  pub selection_follow: bool,
   pub task_report_table: TaskReportTable,
   pub calendar_year: i32,
   pub mode: Mode,
@@ -245,6 +246,7 @@ impl TaskwarriorTui {
       current_selection: 0,
       current_selection_uuid: None,
       current_selection_id: None,
+      selection_follow: true,
       current_context_filter: "".to_string(),
       current_context: "".to_string(),
       command: LineBuffer::with_capacity(MAX_LINE),
@@ -1663,12 +1665,14 @@ impl TaskwarriorTui {
     if force || self.dirty || self.tasks_changed_since(self.last_export).unwrap_or(true) {
       self.get_context()?;
       let task_uuids = self.selected_task_uuids();
-      if self.current_selection_uuid.is_none()
+      if self.selection_follow
+        && self.current_selection_uuid.is_none()
         && self.current_selection_id.is_none()
         && let [uuid] = task_uuids.as_slice()
       {
         self.current_selection_uuid = Some(*uuid);
       }
+      self.selection_follow = true;
 
       self.task_report_table.export_headers(None, &self.report, &self.task_exe)?;
       self.export_tasks()?;
@@ -2441,8 +2445,8 @@ impl TaskwarriorTui {
       None => Err(format!("Unable to run shortcut number {}: shlex::split(`{}`) failed.", s, shell)),
     };
 
-    if let [uuid] = task_uuids.as_slice() {
-      self.current_selection_uuid = Some(*uuid);
+    if !self.config.uda_task_report_jump_to_task_on_modify {
+      self.selection_follow = false;
     }
 
     self.resume_tui().await.unwrap();
@@ -2492,8 +2496,8 @@ impl TaskwarriorTui {
       None => Err(format!("Cannot shlex split `{}`", shell)),
     };
 
-    if let [uuid] = task_uuids.as_slice() {
-      self.current_selection_uuid = Some(*uuid);
+    if !self.config.uda_task_report_jump_to_task_on_modify {
+      self.selection_follow = false;
     }
 
     r

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,6 +101,7 @@ pub struct Config {
   pub uda_task_report_info_show: bool,
   pub uda_task_report_looping: bool,
   pub uda_task_report_jump_to_task_on_add: bool,
+  pub uda_task_report_jump_to_task_on_modify: bool,
   pub uda_selection_indicator: String,
   pub uda_mark_highlight_indicator: String,
   pub uda_unmark_highlight_indicator: String,
@@ -183,6 +184,7 @@ impl Config {
     let uda_task_report_info_show = Self::get_uda_task_report_info_show(data);
     let uda_task_report_looping = Self::get_uda_task_report_looping(data);
     let uda_task_report_jump_to_task_on_add = Self::get_uda_task_report_jump_to_task_on_add(data);
+    let uda_task_report_jump_to_task_on_modify = Self::get_uda_task_report_jump_to_task_on_modify(data);
     let uda_selection_indicator = Self::get_uda_selection_indicator(data);
     let uda_mark_highlight_indicator = Self::get_uda_mark_highlight_indicator(data);
     let uda_unmark_highlight_indicator = Self::get_uda_unmark_highlight_indicator(data);
@@ -266,6 +268,7 @@ impl Config {
       uda_task_report_info_show,
       uda_task_report_looping,
       uda_task_report_jump_to_task_on_add,
+      uda_task_report_jump_to_task_on_modify,
       uda_selection_indicator,
       uda_mark_highlight_indicator,
       uda_unmark_highlight_indicator,
@@ -693,6 +696,13 @@ impl Config {
 
   fn get_uda_task_report_jump_to_task_on_add(data: &str) -> bool {
     Self::get_config("uda.taskwarrior-tui.task-report.jump-to-task-on-add", data)
+      .unwrap_or_default()
+      .get_bool()
+      .unwrap_or(true)
+  }
+
+  fn get_uda_task_report_jump_to_task_on_modify(data: &str) -> bool {
+    Self::get_config("uda.taskwarrior-tui.task-report.jump-to-task-on-modify", data)
       .unwrap_or_default()
       .get_bool()
       .unwrap_or(true)
@@ -1284,6 +1294,17 @@ mod tests {
       "report.test.description test\nreport.test.filter filter and\n                   test",
     );
     assert_eq!(config.unwrap(), "filter and test");
+  }
+
+  #[test]
+  fn test_get_uda_task_report_jump_to_task_on_modify_defaults_to_true() {
+    assert!(Config::get_uda_task_report_jump_to_task_on_modify(""));
+  }
+
+  #[test]
+  fn test_get_uda_task_report_jump_to_task_on_modify_can_be_disabled() {
+    let data = "uda.taskwarrior-tui.task-report.jump-to-task-on-modify false";
+    assert!(!Config::get_uda_task_report_jump_to_task_on_modify(data));
   }
 
   #[test]


### PR DESCRIPTION
Introduces the `uda.taskwarrior-tui.task-report.jump-to-task-on-modify` option (defaults to `true` to maintain the current behavior) to suppress following with the cursor the selection in the next `update()`.

I often triage my tasks sorted by urgency, but every time I modify one it jumps in the list, and the cursor follows it, so I lose my place. Disabling this option makes it so the cursor simply moves to the next task.

See https://github.com/kdheepak/taskwarrior-tui/issues/467#issuecomment-4148002886